### PR TITLE
java.sql.SQLException-Handling

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -114,7 +114,7 @@
       (catch Exception e
         (println "Failure to execute query with SQL:")
         (println sql " :: " params)
-        (if (instance? java.sql.SqlException e)
+        (if (instance? java.sql.SQLException e)
           (jdbc/print-sql-exception e)
           (println e) )
         ))))


### PR DESCRIPTION
clojure.java.jdbc/print-sql-exception only prints .. well SQLException
but the postgres driver can throw RuntimeExceptions, so added a check to print other exceptions to korma.db/do-query 
