### PR TITLE
Support custom ON clauses in JOIN statements

### DIFF
--- a/src/korma/internal/sql.clj
+++ b/src/korma/internal/sql.clj
@@ -268,12 +268,16 @@
                (map-val v))
     :else (table-str v)))
 
-(defn join-clause [join-type table pk fk]
+(defn on-clause [clause]
+  (if (string? clause)
+    clause
+    (map-val clause)))
+
+(defn join-clause [join-type table clause]
   (let [join-type (string/upper-case (name join-type))
         table (from-table table)
-        join (str " " join-type " JOIN " table " ON ")
-        on-clause (str (field-str pk) " = " (field-str fk))]
-    (str join on-clause)))
+        join (str " " join-type " JOIN " table " ON ")]
+    (str join (on-clause clause))))
 
 (defn insert-values-clause [ks vs]
   (for [v vs]
@@ -323,8 +327,8 @@
     (update-in query [:sql-str] str neue-sql))))
 
 (defn sql-joins [query]
-  (let [clauses (for [[type table pk fk] (:joins query)]
-                  (join-clause type table pk fk))
+  (let [clauses (for [[type table keys] (:joins query)]
+                  (join-clause type table keys))
         clauses-str (string/join "" clauses)]
     (update-in query [:sql-str] str clauses-str)))
 

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -166,8 +166,8 @@
 (deftest join-order
          (sql-only
            (is (= (select users 
-                    (join :user2 :users.id :user2.users_id)
-                    (join :user3 :users.id :user3.users_id))
+                    (join :user2 (= :users.id :user2.users_id))
+                    (join :user3 (= :users.id :user3.users_id)))
                   "SELECT \"users\".* FROM \"users\" LEFT JOIN \"user2\" ON \"users\".\"id\" = \"user2\".\"users_id\" LEFT JOIN \"user3\" ON \"users\".\"id\" = \"user3\".\"users_id\""))))
 
 (deftest aggregate-group


### PR DESCRIPTION
I needed to be able to vary the ON clause in JOIN statements, so I added support to Korma.

My thinking was that `join` should work like `where`, so my approach makes a breaking change to the `join` syntax:

```
(select users (join items (= :users.id :items.user_id)))
```

Instead of:

```
(select users (join items :users.id :items.user_id))
```

The implementation also supports a map of pairs, like `where`.

It would be great to get something like this into Korma!  Let me know what you think.
