### PR TITLE
Add a not-in predicate function

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -159,6 +159,7 @@
                  'or 'korma.sql.fns/pred-or
                  'not 'korma.sql.fns/pred-not
                  'in 'korma.sql.fns/pred-in
+                 'not-in 'korma.sql.fns/pred-not-in
                  '> 'korma.sql.fns/pred->
                  '< 'korma.sql.fns/pred-<
                  '>= 'korma.sql.fns/pred->=

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -11,6 +11,7 @@
 (defn pred-not [v] (wrapper "NOT" v))
 
 (defn pred-in [k v] (infix k "IN" v))
+(defn pred-not-in [k v] (infix k "NOT IN" v))
 (defn pred-> [k v] (infix k ">" v))
 (defn pred-< [k v] (infix k "<" v))
 (defn pred->= [k v] (infix k ">=" v))

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -321,6 +321,14 @@
              (exec)))
          "SELECT MIN(\"the_table\".\"date_created\") \"start_date\", MAX(\"the_table\".\"date_created\") \"end_date\" FROM \"the_table\" WHERE (\"the_table\".\"id\" IN (?, ?, ?))")))
 
+(deftest not-in
+  (defentity the_table)
+  (is (= (sql-only
+           (-> (select* the_table)
+             (where {:id [not-in [1 2 3]]})
+             (exec)))
+         "SELECT \"the_table\".* FROM \"the_table\" WHERE (\"the_table\".\"id\" NOT IN (?, ?, ?))")))
+
 (deftest subselect-table-prefix
   (defentity first_table)
   (is (= (sql-only


### PR DESCRIPTION
This can be simulated by a combination of (not (in x)) forms, but it feels much simpler to me to simply use not-in. If you have reason for not wanting this functionality, I would be curious as to your reasoning, as I'm new to clojure, and might have failed to grasp some element of the language.

Thanks for SQL Korma!
