### PR TITLE
Added support for customizing connection pools

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -35,7 +35,7 @@
 (defn delay-pool
   "Return a delay for creating a connection pool for the given spec."
   [spec]
-  (delay (connection-pool spec)))
+  (delay ((spec :connection-pool-factory connection-pool) spec)))
 
 (defn get-connection
   "Get a connection from the potentially delayed connection object."


### PR DESCRIPTION
Hi,

Attached patch adds :connection-pool-factory attribute to db spec. 

Example:

```
(defn create-bonecp-connection-pool
  (let [connection-pool (doto (BoneCPDataSource.)
                      (.setDriverClass (spec :classname))
                      (.setJdbcUrl (str "jdbc:" (:subprotocol spec) ":" (:subname spec)))
                      (.setUsername (:user spec))
                      (.setPassword (:password spec))
                      (.setPartitionCount 3)
                      (.setMaxConnectionsPerPartition 26)
                      (.setStatementsCacheSize 100)
                      )]
 {:datasource connection-pool}))

(def database-config
  {:classname "org.postgresql.Driver"
   :subprotocol "postgresql"
   :user "..."
   :password "..."
   :subname "//localhost/some_db"
   :connection-pool-factory create-bonecp-connection-pool
 })
```
