### PR TITLE
A nicer way to specify connection pool implementation

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -35,7 +35,9 @@
 (defn delay-pool
   "Return a delay for creating a connection pool for the given spec."
   [spec]
-  (delay (connection-pool spec)))
+  (if (:datasource spec)
+    (delay {:datasource (:datasource spec)})
+    (delay (connection-pool spec))))
 
 (defn get-connection
   "Get a connection from the potentially delayed connection object."

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -3,10 +3,12 @@
   (:use [korma.core]
         [korma.db]
         [korma.config])
+  (:import [com.mchange.v2.c3p0 ComboPooledDataSource])
   (:use [clojure.test]))
 
 (defdb test-db-opts (postgres {:db "korma" :user "korma" :password "kormapass" :delimiters "" :naming {:fields string/upper-case}}))
 (defdb test-db (postgres {:db "korma" :user "korma" :password "kormapass"}))
+(defdb test-db-datasource (postgres {:datasource :dummy-datasource}))
 
 (defentity delims
   (database test-db-opts))
@@ -377,3 +379,13 @@
          (select :test (where {:cool [in []]}))
          "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"cool\" IN (NULL))"
          )))
+
+(deftest datasource-configuration
+  (let [pool (:pool test-db-datasource)
+        datasource (:datasource @pool)]
+    (is (= datasource :dummy-datasource))))
+
+(deftest default-connection-pool
+  (let [pool (:pool test-db)
+        datasource (:datasource @pool)]
+    (is (= (.getClass datasource) ComboPooledDataSource))))


### PR DESCRIPTION
If db-spec contains key :datasource, the corresponding value is used as a datasource without creating a C3P0 connection pool. Typical use case is that application creates connection pool itself and passes the connection pool to korma.
