### PR TITLE
Better SQLException error message

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -148,9 +148,9 @@
   (println "Failure to execute query with SQL:")
   (println sql " :: " params)
   (cond
-    (instance? java.sql.SQLException e) (jdbc/print-sql-exception e)
+    (instance? java.sql.SQLException e) (jdbc/print-sql-exception (.getNextException e))
     :else (.printStackTrace e))
-  (throw e))
+  (throw (.getNextException e)))
 
 (defn- exec-sql [query]
   (let [results? (:results query)


### PR DESCRIPTION
Currently if a SQLException is handled, all we do is jdbc/print-sql-exception on the BatchUpdateException which doesn't give us much to work with.  By calling .getNextException on the handled exception, we get the actual SQL error which is much more informative.
