### PR TITLE
The default port for MS SQL Server

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -107,7 +107,7 @@
   for :db, :user, and :password. You can also optionally set host and port."
   [{:keys [user password db host port] :as opts}]
   (let [host (or (:host opts) "localhost")
-        port (or (:port opts) 5432)
+        port (or (:port opts) 1433)
         user (or user "dbuser")
         password (or password "dbpassword")
         db (or (:db opts) "")]


### PR DESCRIPTION
The default port for MS SQL Server is 1433.

Thanks!
