### PR TITLE
New macros for many-to-many relationships

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject korma "0.3.0-beta12"
+(defproject korma "0.3.0-beta13"
   :description "Tasty SQL for Clojure"
   :url "http://github.com/ibdknox/korma"
   :dependencies [[org.clojure/clojure "1.3.0"]

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -45,6 +45,32 @@
            (as-sql))
          "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\" WHERE (\"users\".\"username\" = ?) ORDER BY \"users\".\"created\" ASC LIMIT 5 OFFSET 3")))
 
+(deftest select-where-one-relation
+  (is (= (-> (select* user2)
+           (fields :id :username)
+           (where {:username "chris"})
+           (where-relations {:address 1})
+           (transform-where)
+           (as-sql))
+         "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\" WHERE (\"users\".\"username\" = ?) AND (\"users\".\"address_id\" = ?)")))
+
+(deftest select-where-many-relation
+  (is (= (-> (select* user2)
+           (fields :id :username)
+           (where {:username "chris"})
+           (where-relations {:email 1})
+           (transform-where)
+           (as-sql))
+         "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\" INNER JOIN \"email\" ON \"users\".\"id\" = \"email\".\"users_id\" WHERE (\"users\".\"username\" = ?) AND (\"email\".\"users_id\" = ?)")))
+
+(deftest select-where-many-to-many-relation
+  (is (= (-> (select* employees)
+           (fields :id :username)
+           (where {:username "chris"})
+           (where-relations {:roles 1})
+           (transform-where)
+           (as-sql))
+         "SELECT \"employees\".\"id\", \"employees\".\"username\" FROM \"employees\" INNER JOIN \"employees2roles\" ON \"employees\".\"id\" = \"employees2roles\".\"employees_id\" WHERE (\"employees\".\"username\" = ?) AND (\"employees2roles\".\"roles_id\" = ?)")))
 
 (deftest simple-selects
   (sql-only


### PR DESCRIPTION
Hello Chris, i enjoyed using your great korma library but i missed the many-to-many relations feature so i implemented 2 new macros: has-many-to-many and belongs-to-many-to-many. Maybe their naming is little bit crude but i didn't want it to be confusing with existing 'has-many' and 'belongs-to' macros creating many-to-one and one-to-many relations. When 'with' macro is used, it works the same way as with 'has-many' relation, so referenced sub-entity is lazily fetched with post select for each main record from result-set. 
Of course mapping table entity2entity must exist for many to many relationships, default name for this table is entity2sub-entity when using:

(defentity entity
  (has-many-to-many sub-entity))

and sub-entity2entity when using:

(defentity entity
  (belongs-to-many-to-many sub-entity))

this default name could be overriden in supplied opts map (key :map-table), as is it possible with keys in mapping table.
