### PR TITLE
Connection Pooling Min and Max Setting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
                  [c3p0/c3p0 "0.9.1.2"]
                  [org.clojure/java.jdbc "0.2.2"]]
   :codox {:exclude [korma.sql.engine korma.sql.fns korma.sql.utils]}
-          :dev-dependencies [[postgresql "9.0-801.jdbc4"]])
+          :dev-dependencies [[postgresql "9.0-801.jdbc4"]
+                             [com.h2database/h2 "1.3.164"]])

--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -22,13 +22,19 @@
   [spec]
   (let [excess (or (:excess-timeout spec) (* 30 60))
         idle (or (:idle-timeout spec) (* 3 60 60))
+        minimum-pool-size (or (:minimum-pool-size spec) 3)
+        maximum-pool-size (or (:maximum-pool-size spec) 15)
+
         cpds (doto (ComboPooledDataSource.)
                (.setDriverClass (:classname spec))
                (.setJdbcUrl (str "jdbc:" (:subprotocol spec) ":" (:subname spec)))
                (.setUser (:user spec))
                (.setPassword (:password spec))
                (.setMaxIdleTimeExcessConnections excess)
-               (.setMaxIdleTime idle))]
+               (.setMaxIdleTime idle)
+               (.setMinPoolSize minimum-pool-size)
+               (.setMaxPoolSize maximum-pool-size))]
+
     {:datasource cpds}))
 
 (defn delay-pool

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -1,0 +1,27 @@
+(ns korma.test.db
+  (:use
+    [clojure.test]
+    [korma.db]))
+
+(def ^{:private true} db-config-with-pooling
+  {:classname "org.h2.Driver"
+   :subprotocol "h2"
+   :subname "mem:db_connectivity_test_db"
+   :minimum-pool-size 5
+   :maximum-pool-size 20}
+  )
+
+(deftest connection-pooling-default-test
+  (let [db-config-default (dissoc db-config-with-pooling :minimum-pool-size :maximum-pool-size)
+        pool (connection-pool db-config-default)
+        datasource (get pool :datasource)]
+    (is (= (.getMaxPoolSize datasource) 15))
+    (is (= (.getMinPoolSize datasource) 3))
+    ))
+
+(deftest connection-pooling-test
+  (let [pool (connection-pool db-config-with-pooling)
+        datasource (get pool :datasource)]
+    (is (= (.getMaxPoolSize datasource) 20))
+    (is (= (.getMinPoolSize datasource) 5))
+    ))


### PR DESCRIPTION
I've added the ability to specify the connection pool min and max sizes since the default C3P0 settings aren't
really suitable for all production applications.

Commit comments:
a connection pool min and max, the defaults
for min and max map directly to the defaults 
that come from the C3P0 library

also filling in tests for the db/connection-pool
function asserting that the min and max settings
work as well as the defaults
