### PR TITLE
#82: add between predicate

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -181,7 +181,7 @@
   with keywords used to reference fields.
   e.g. (where query (or (= :hits 1) (> :hits 5)))
 
-  Available predicates: and, or, =, not=, <, >, <=, >=, in, like, not
+  Available predicates: and, or, =, not=, <, >, <=, >=, in, like, not, between
 
   Where can also take a map at any point and will create a clause that compares keys
   to values. The value can be a vector with one of the above predicate functions 

--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -163,6 +163,7 @@
                  'not 'korma.sql.fns/pred-not
                  'in 'korma.sql.fns/pred-in
                  'not-in 'korma.sql.fns/pred-not-in
+                 'between 'korma.sql.fns/pred-between
                  '> 'korma.sql.fns/pred->
                  '< 'korma.sql.fns/pred-<
                  '>= 'korma.sql.fns/pred->=
@@ -179,6 +180,14 @@
 
 (defn do-wrapper [op v]
   (str op (utils/wrap (str-value v))))
+
+(defn do-trinary [k op v1 sep v2]
+  (-> [(str-value k) op (str-value v1) sep (str-value v2)]
+      utils/space
+      utils/wrap))
+
+(defn trinary [k op v1 sep v2]
+  (utils/pred do-trinary [(try-prefix k) op (try-prefix v1) sep (try-prefix v2)]))
 
 (defn infix [k op v]
   (utils/pred do-infix [(try-prefix k) op (try-prefix v)]))

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -1,7 +1,7 @@
 (ns ^{:no-doc true}
   korma.sql.fns
   (:require [korma.sql.engine :as eng])
-  (:use [korma.sql.engine :only [infix group-with wrapper sql-func]]))
+  (:use [korma.sql.engine :only [infix group-with wrapper sql-func trinary]]))
 
 ;;*****************************************************
 ;; Predicates
@@ -18,6 +18,9 @@
 (defn pred->= [k v] (infix k ">=" v))
 (defn pred-<= [k v] (infix k "<=" v))
 (defn pred-like [k v] (infix k "LIKE" v))
+
+(defn pred-between [k [v1 v2]]
+  (trinary k "BETWEEN" v1 "AND" v2))
 
 (def pred-= eng/pred-=)
 (defn pred-not= [k v] (cond


### PR DESCRIPTION
Follows the pattern of having helpers for predicates with a given syntax pattern (in this case `trinary`, since `ternary` is so frequently used to refer to a _specific_ three-operand operator).
