### PR TITLE
fixed issue with set-fields not applying db delimiters

### DIFF
--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -63,3 +63,8 @@
      (update users-live-mysql (set-fields {:name "THIAGO"}) (where {:name "thiago"}))))
 
   (clean-korma-db))
+
+(deftest mysql-delim-options
+  (sql-only
+    (is (= (update users-mysql (set-fields {:field "value"}))
+           "UPDATE `users-mysql` SET `field` = ?"))))


### PR DESCRIPTION
I had an issue where, using a mysql database, not all of my column names were having the delimiters applied correct.

My query looked similar to this:

(update client (set-fields {:joindate somedate}) (where {:id id}))

I found the id field was handled correctly i.e. was translated to `id`, but the joindate field was not. It ended up being translated to "joindate" (which is not valid in mysql), rather than `joindate`
