### PR TITLE
don't get-connection when there is already an open connection

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -167,10 +167,10 @@
       (catch Exception e (handle-exception e sql params)))))
 
 (defn do-query [query]
-  (let [conn (when-let[db (:db query)]
-               (get-connection db))
-        cur (or conn (get-connection @_default))
-        prev-conn (jdbc/find-connection)
+  (let [prev-conn (jdbc/find-connection)
+        conn (if-not prev-conn (when-let[db (:db query)]
+                                 (get-connection db)))
+        cur (if-not prev-conn (or conn (get-connection @_default)))
         opts (or (:options query) @conf/options)]
     (jdbc/with-naming-strategy (->strategy (:naming opts))
       (if-not prev-conn


### PR DESCRIPTION
(same as pull-request 88 https://github.com/korma/Korma/pull/88 but without the private maven groupid commit)

---

if there is an open connection, as found by (jdbc/find-connection), do-query was calling get-connection and then ignoring the results in favour of the already open connection

this patch avoids calling get-connection when there is an already open connection, which permits a connection to be opened outside of korma
