### PR TITLE
Pass query-fn as symbol to make-query-then-exec

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -104,7 +104,6 @@
 ;;*****************************************************
 
 (defmacro make-query-then-exec [query-fn body & args]
-  (prn query-fn body args)
   ``(let [~'query# (-> (~~query-fn ~~@args)
                        ~@~body)]
       (exec ~'query#)))


### PR DESCRIPTION
Passing query-fn as a function value rather than a symbol to
make-query-then-exec will under certain circumstances lead to an
ExceptionInInitializerError with a cause describing that the respective
function was not defined. It is not clear how to reproduce this
situation but it's cleaner to pass a symbol in this case, anyway.
