### PR TITLE
MySQL with Replication Driver

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -106,6 +106,21 @@
           :make-pool? make-pool?}
          opts))
 
+(defn mysql-replicated
+  "Create a database specification for a mysql database with replication enabled.
+  Opts should include keys for :db, :user, and :password. You can also optionally
+  set hosts and make the connection pooled. Delimiters are automatically set
+  to \"`\"."
+  [{:keys [hosts db make-pool?]
+    :or {hosts "localhost:3306,localhost:3306" db "" make-pool? true}
+    :as opts}]
+  (merge {:classname "com.mysql.jdbc.ReplicationDriver"
+          :subprotocol "mysql:replication"
+          :subname (str "//" hosts "/" db)
+          :delimiters "`"
+          :make-pool? make-pool?}
+         opts))
+
 (defn mssql
   "Create a database specification for a mssql database. Opts should include keys
   for :db, :user, and :password. You can also optionally set host and port."

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -1,7 +1,7 @@
 (ns korma.test.db
   (:use [clojure.test :only [deftest is testing]]
         [korma.db :only [connection-pool defdb get-connection h2
-                         mssql mysql oracle postgres sqlite3]]))
+                         mssql mysql mysql-replicated oracle postgres sqlite3]]))
 
 
 (def db-config-with-defaults
@@ -105,6 +105,26 @@
             :make-pool? false}
            (mysql {:host "host"
                    :port "port"
+                   :db "db"
+                   :make-pool? false})))))
+
+(deftest test-mysql-replicated
+  (testing "mysql replicated - defaults"
+    (is (= {:classname "com.mysql.jdbc.ReplicationDriver"
+            :subprotocol "mysql:replication"
+            :subname "//localhost:3306,localhost:3306/"
+            :delimiters "`"
+            :make-pool? true}
+           (mysql-replicated {}))))
+  (testing "mysql replicated - options selected"
+    (is (= {:db "db"
+            :hosts "master,slave1,slave2"
+            :classname "com.mysql.jdbc.ReplicationDriver"
+            :subprotocol "mysql:replication"
+            :subname "//master,slave1,slave2/db"
+            :delimiters "`"
+            :make-pool? false}
+           (mysql-replicated {:hosts "master,slave1,slave2"
                    :db "db"
                    :make-pool? false})))))
 


### PR DESCRIPTION
By using the mysql-replicated, instead of the mysql function, the user will be able to do master/slave configuration, specifying the hosts in the :hosts key, comma separated.
