### PR TITLE
s/vector?/sequential?/ when applying transform functions

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -437,7 +437,7 @@
     results
     (if-let [trans (seq (-> query :ent :transforms))]
       (let [trans-fn (apply comp trans)]
-        (if (vector? results) (map trans-fn results) (trans-fn results)))
+        (if (sequential? results) (map trans-fn results) (trans-fn results)))
       results)))
 
 (defn- apply-prepares

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -609,3 +609,14 @@
                                                                         :c 3})))
                                            (order :a)))))))
 
+(defentity foos-abc-2)
+
+(defentity foos-abc-1
+  (has-many foos-abc-2)
+  (transform #(assoc % :bar :baz)))
+
+;; Tests that transform functions work correctly with (with ...)
+(deftest transform-fn-test
+  (with-redefs [do-query (constantly [{:id 12}])]
+    (is (= [{:id 12, :bar :baz, :foos-abc-2 [{:id 12}]}]
+           (select foos-abc-1 (with foos-abc-2))))))


### PR DESCRIPTION
The transform function code decides whether or not to use `map` by
testing with `vector?`, which breaks when the result set is a seq
instead, as is the case when you do a query of the form
`(select foos (with bars))`. As far as I can tell this could be
fixed either by replacing the `vector?` test with a `sequential?`
test, or using a `mapv` in `apply-posts` (and maybe elsewhere).

This commit implements the former, and adds a test.