### PR TITLE
Use optional AS keyword in alias clauses

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -97,7 +97,7 @@
 
 (defn alias-clause [alias]
   (when alias
-    (str " " (delimit-str (name alias)))))
+    (str " AS " (delimit-str (name alias)))))
 
 (defn field-str [v]
     (let [[fname alias] (if (vector? v)

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -47,7 +47,7 @@
          (select users)
          "SELECT \"users\".* FROM \"users\""
          (select users-alias)
-         "SELECT \"u\".* FROM \"users\" \"u\""
+         "SELECT \"u\".* FROM \"users\" AS \"u\""
          (select users
                  (fields :id :username))
          "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
@@ -201,9 +201,9 @@
   (sql-only
     (is (= "SELECT \"users\".* FROM \"users\" GROUP BY \"users\".\"id\", \"users\".\"name\""
            (select users (group :id :name))))
-    (is (= "SELECT COUNT(\"users\".*) \"cnt\" FROM \"users\" GROUP BY \"users\".\"id\""
+    (is (= "SELECT COUNT(\"users\".*) AS \"cnt\" FROM \"users\" GROUP BY \"users\".\"id\""
            (select users (aggregate (count :*) :cnt :id))))
-    (is (= "SELECT COUNT(\"users\".*) \"cnt\" FROM \"users\" GROUP BY \"users\".\"id\" HAVING (\"users\".\"id\" = ?)"
+    (is (= "SELECT COUNT(\"users\".*) AS \"cnt\" FROM \"users\" GROUP BY \"users\".\"id\" HAVING (\"users\".\"id\" = ?)"
             (select users
                    (aggregate (count :*) :cnt :id)
                    (having {:id 5}))))))
@@ -215,7 +215,7 @@
 
 (deftest sqlfns
   (sql-only
-    (is (= "SELECT NOW() \"now\", MAX(\"users\".\"blah\"), AVG(SUM(?, ?), SUM(?, ?)) FROM \"users\" WHERE (\"users\".\"time\" >= NOW())"
+    (is (= "SELECT NOW() AS \"now\", MAX(\"users\".\"blah\"), AVG(SUM(?, ?), SUM(?, ?)) FROM \"users\" WHERE (\"users\".\"time\" >= NOW())"
            (select users
                    (fields [(sqlfn now) :now] (sqlfn max :blah) (sqlfn avg (sqlfn sum 3 4) (sqlfn sum 4 5)))
                    (where {:time [>= (sqlfn now)]}))))))
@@ -316,13 +316,13 @@
                  (where {:id [in (subselect users
                                             (where {:age [> 5]}))]})))
 
-       "SELECT \"users\".* FROM \"users\", (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) \"u2\""
+       "SELECT \"users\".* FROM \"users\", (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) AS \"u2\""
        (sql-only
          (select users
                  (from [(subselect users
                                    (where {:age [> 5]})) :u2])))
 
-       "SELECT \"users\".*, (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) \"u2\" FROM \"users\""
+       "SELECT \"users\".*, (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) AS \"u2\" FROM \"users\""
        (sql-only
          (select users
                  (fields :* [(subselect users
@@ -345,7 +345,7 @@
 
 (deftest multiple-aggregates
   (defentity the_table)
-  (is (= "SELECT MIN(\"the_table\".\"date_created\") \"start_date\", MAX(\"the_table\".\"date_created\") \"end_date\" FROM \"the_table\" WHERE (\"the_table\".\"id\" IN (?, ?, ?))"
+  (is (= "SELECT MIN(\"the_table\".\"date_created\") AS \"start_date\", MAX(\"the_table\".\"date_created\") AS \"end_date\" FROM \"the_table\" WHERE (\"the_table\".\"id\" IN (?, ?, ?))"
          (sql-only
            (-> (select* the_table)
              (aggregate (min :date_created) :start_date)
@@ -381,7 +381,7 @@
                  (table (subselect "test")))))
 
   (are [result query] (= result query)
-       "SELECT \"test\".* FROM (SELECT \"test\".* FROM \"test\") \"test\""
+       "SELECT \"test\".* FROM (SELECT \"test\".* FROM \"test\") AS \"test\""
        (sql-only
          (select subsel))))
 
@@ -391,7 +391,7 @@
 
   (sql-only
     (are [result query] (= result query)
-         "SELECT \"bb\".* FROM \"blah\" \"bb\" LEFT JOIN \"blah\" \"not-bb\" ON \"bb\".\"cool\" = \"not-bb\".\"cool2\""
+         "SELECT \"bb\".* FROM \"blah\" AS \"bb\" LEFT JOIN \"blah\" AS \"not-bb\" ON \"bb\".\"cool\" = \"not-bb\".\"cool2\""
          (select blahblah (join [blahblah :not-bb] (= :bb.cool :not-bb.cool2))))))
 
 (deftest empty-in-clause

--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -14,18 +14,18 @@
 (deftest test-mysql-count
   (sql-only
     (are [result query] (= result query)
-      "SELECT COUNT(*) `cnt` FROM `users-mysql` GROUP BY `users-mysql`.`id`"
+      "SELECT COUNT(*) AS `cnt` FROM `users-mysql` GROUP BY `users-mysql`.`id`"
       (select users-mysql (aggregate (mysql/count :*) :cnt :id))
 
-      "SELECT COUNT(`users-non-mysql`.*) `cnt` FROM `users-non-mysql` GROUP BY `users-non-mysql`.`id`"
+      "SELECT COUNT(`users-non-mysql`.*) AS `cnt` FROM `users-non-mysql` GROUP BY `users-non-mysql`.`id`"
       (select users-non-mysql (aggregate (count :*) :cnt :id))
 
-      "SELECT COUNT(*) `cnt` FROM `users-mysql` GROUP BY `users-mysql`.`id` HAVING (`users-mysql`.`id` = ?)"
+      "SELECT COUNT(*) AS `cnt` FROM `users-mysql` GROUP BY `users-mysql`.`id` HAVING (`users-mysql`.`id` = ?)"
       (select users-mysql
              (aggregate (mysql/count :*) :cnt :id)
              (having {:id 5}))
 
-      "SELECT COUNT(`users-mysql`.`id`) `cnt` FROM `users-mysql`"
+      "SELECT COUNT(`users-mysql`.`id`) AS `cnt` FROM `users-mysql`"
       (select users-mysql (aggregate (mysql/count :id) :cnt)))))
 
 
@@ -35,5 +35,5 @@
   (defdb test-db-mysql (mysql {:db "korma" :user "korma" :password "kormapass"}))
 
   (sql-only
-   (is (= "SELECT COUNT(*) `cnt` FROM `users-no-db-specified` GROUP BY `users-no-db-specified`.`id`"
+   (is (= "SELECT COUNT(*) AS `cnt` FROM `users-no-db-specified` GROUP BY `users-no-db-specified`.`id`"
           (select users-no-db-specified (aggregate (count :*) :cnt :id))))))


### PR DESCRIPTION
Modified engine to use AS keyword. Also fixed affected unit tests
which cover aliases for fields, tables, and subselects.

This change is primarily motivated by my use of Microsoft Access, which seems to choke without the keyword.  However, I believe the AS keyword is syntactically legitimate SQL and should work with all the major SQL dialects.  The intent is not so much to add vendor-specific support, but to choose generic syntax that supports the broadest spectrum of vendors.
