### PR TITLE
Use <> instead of != in relational comparisons

### DIFF
--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -28,7 +28,7 @@
 
 (def pred-= eng/pred-=)
 (defn pred-not= [k v] (cond
-                        (and k v) (infix k "!=" v)
+                        (and k v) (infix k "<>" v)
                         k         (infix k "IS NOT" v)
                         v         (infix v "IS NOT" k)))
 

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -434,7 +434,7 @@
 
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" NOT IN (?, ?, ?))"
         (select :test (where {:id [not-in [1 2 3]]}))
-        "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" != ?)"
+        "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" <> ?)"
         (select :test (where {:id [not= 1]})))))
 
 


### PR DESCRIPTION
Using this form of comparison allows Microsoft Access queries
that test for inequality to use the normal predicate syntax
instead of calling the 'raw' function. I believe <> is valid
generic SQL and still works with all the other vendors.

The spirit of this request is to include the widest possible range of vendors using generic SQL syntax.
