### PR TITLE
Add stdev aggregate

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -238,6 +238,7 @@
                  'first 'korma.sql.fns/agg-first
                  'last 'korma.sql.fns/agg-last
                  'avg 'korma.sql.fns/agg-avg
+                 'stdev 'korma.sql.fns/agg-stdev
                  'sum 'korma.sql.fns/agg-sum})
 
 (defn sql-func [op & vs]

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -47,6 +47,7 @@
 
 (defn agg-sum [_query_ v]   (sql-func "SUM" v))
 (defn agg-avg [_query_ v]   (sql-func "AVG" v))
+(defn agg-stdev [_query_ v] (sql-func "STDEV" v))
 (defn agg-min [_query_ v]   (sql-func "MIN" v))
 (defn agg-max [_query_ v]   (sql-func "MAX" v))
 (defn agg-first [_query_ v] (sql-func "FIRST" v))

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -208,6 +208,11 @@
                    (aggregate (count :*) :cnt :id)
                    (having {:id 5}))))))
 
+(deftest aggregate-stdev
+  (sql-only
+    (is (= "SELECT STDEV(\"users\".\"age\") AS \"DevAge\" FROM \"users\""
+           (select users (aggregate (stdev :age) :DevAge))))))
+
 (deftest quoting
   (sql-only
     (is (= "SELECT \"users\".\"testField\", \"users\".\"t!\" FROM \"users\""


### PR DESCRIPTION
Though I don't think all dialects support stdev, this change allows
those that do to use the same syntax as for other aggregates,
instead of having to use 'raw' or other work-arounds.
