### PR TITLE
Unit Tests Sensitive to Platform-specific Line Endings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
              :1.5.0 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}}
   :aliases {"run-tests" ["with-profile" "1.3.0:1.4.0:1.5.0" "test"]
             "slamhound" ["run" "-m" "slam.hound"]}
+  :jvm-opts ["-Dline.separator=\n"]
 
   ;; Lein1 - will be removed at some point
   :dependencies [[org.clojure/clojure "1.3.0"]


### PR DESCRIPTION
Ideally, 'lein test' should work out-of-the-box for new korma users.  As it is, Windows users have to try and convince the JVM to use "\n" instead of "\r\n".  I believe the Java system property 'line.separator' is what controls this. It can be set from the java command line.or via the :jvm-opts key in the leiningen project file.

Editing my project file to add the line below worked for me

```
:jvm-opts ["-Dline.separator=\n"]
```

This is a very minor issue, but a nuisance nontheless.  Thank you.
