### PR TITLE
Add db-spec creator for MS Access database

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -118,6 +118,20 @@
           :make-pool? make-pool?} 
          opts))
 
+(defn msaccess
+  "Create a database specification for a Microsoft Access database. Opts
+  should include keys for :db and optionally :make-pool?."
+  [{:keys [db make-pool?]
+    :or {db "", make-pool? false}
+    :as opts}]
+  (merge {:classname "sun.jdbc.odbc.JdbcOdbcDriver" ; must be in classpath
+          :subprotocol "odbc"
+          :subname (str "Driver={Microsoft Access Driver (*.mdb"
+                        (when (.endsWith db ".accdb") ", *.accdb")
+                        ")};Dbq=" db)
+          :make-pool? make-pool?}
+         opts))
+
 (defn odbc
   "Create a database specification for an ODBC DSN. Opts
   should include keys for :dsn and optionally :make-pool?."

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -1,7 +1,7 @@
 (ns korma.test.db
   (:use [clojure.test :only [deftest is testing]]
         [korma.db :only [connection-pool defdb get-connection h2
-                         mssql mysql odbc oracle postgres sqlite3]]))
+                         msaccess mssql mysql odbc oracle postgres sqlite3]]))
 
 
 (def db-config-with-defaults
@@ -131,6 +131,29 @@
                    :user "user"
                    :password "password"
                    :make-pool? false})))))
+
+(deftest test-msaccess
+  (testing "msaccess - defaults"
+    (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
+            :subprotocol "odbc"
+            :subname "Driver={Microsoft Access Driver (*.mdb)};Dbq="
+            :make-pool? false}
+           (msaccess {}))))
+  (testing "msaccess - .mdb selected"
+    (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
+            :subprotocol "odbc"
+            :subname "Driver={Microsoft Access Driver (*.mdb)};Dbq=db.mdb"
+            :db "db.mdb"
+            :make-pool? true}
+           (msaccess {:db "db.mdb" :make-pool? true}))))
+  (testing "msaccess - .accdb selected"
+    (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
+            :subprotocol "odbc"
+            :subname (str "Driver={Microsoft Access Driver (*.mdb, *.accdb)};"
+                          "Dbq=db.accdb")
+            :db "db.accdb"
+            :make-pool? true}
+           (msaccess {:db "db.accdb" :make-pool? true})))))
 
 (deftest test-odbc
   (testing "odbc - defaults"


### PR DESCRIPTION
Added another convenience function and some tests.  Note that `:make-pool?` defaults to false in this case.  That's because on my Windows 7 laptop, setting it to true caused an exception.  Also, there are two test cases with options as there are two ODBC drivers for Microsoft Access: one for the older `*.mdb` files and another that also supports the newer `*.accdb` databases.

Without connection pooling, the `msaccess` function works with both database types on my laptop.
