### PR TITLE
User-specified naming strategies don't work

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.vgeshel/korma "0.3.0-RC3-vg"
+(defproject korma "0.3.0-RC3"
   :description "Tasty SQL for Clojure"
   :url "http://github.com/ibdknox/korma"
   :mailing-list {:name "Korma Google Group"


### PR DESCRIPTION
Specifying a naming strategy either with a :naming option of a datasource map, or with korma.config/set-naming, has no effect. This is because in

``` clojure
{:keys [db options] :or {options @conf/options} :as query}
```

the :or clause takes effect when the :options key in query is missing, but not when it's present and its value is nil. The way query maps are built in korma.core, the :options key is always present:

``` clojure
(defn empty-query [ent]
  (let [ent (if (keyword? ent)
              (name ent)
              ent)
        [ent table alias db opts] (if (string? ent)
                                    [{:table ent} ent nil nil nil]
                                    [ent (:table ent) (:alias ent) (:db ent) (get-in ent [:db :options])])]
    {:ent ent
     :table table
     :db db
     :options opts
     :alias alias}))
```

The fix is pretty obvious.
