### PR TITLE
Make korea.sql.engine/bind-params public

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -385,7 +385,7 @@
 ;; To sql
 ;;*****************************************************
 
-(defmacro ^{:private true} bind-params [& body]
+(defmacro bind-params [& body]
   `(binding [*bound-params* (atom [])]
      (let [query# (do ~@body)]
        (update-in query# [:params] utils/vconcat @*bound-params*))))


### PR DESCRIPTION
Korma.incubator relies on this being public (see https://github.com/korma/korma.incubator/blob/master/src/korma/incubator/core.clj#L10), this pr fixes current breakage.
