### PR TITLE
Bug: Nested transactions deadlock with MYSQL.

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -171,9 +171,11 @@
 (defmacro transaction
   "Execute all queries within the body in a single transaction."
   [& body]
-  `(jdbc/with-connection (get-connection @_default)
-     (jdbc/transaction
-       ~@body)))
+  `(if (jdbc/find-connection)
+     (jdbc/transaction ~@body)
+     (jdbc/with-connection (get-connection @_default)
+       (jdbc/transaction
+        ~@body))))
 
 (defn rollback
   "Tell this current transaction to rollback."

--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -37,3 +37,11 @@
   (sql-only
    (is (= "SELECT COUNT(*) AS `cnt` FROM `users-no-db-specified` GROUP BY `users-no-db-specified`.`id`"
           (select users-no-db-specified (aggregate (count :*) :cnt :id))))))
+
+(deftest test-nested-transactions-work
+  (defdb test-db-mysql (mysql {:db "korma" :user "korma" :password "kormapass"}))
+
+  (transaction
+   (insert users-mysql (values {:name "thiago"}))
+    (transaction
+     (update users-mysql (set-fields {:name "THIAGO"}) (where {:name "thiago"})))))


### PR DESCRIPTION
If you are in a nested transaction you already have a connection open. Trying to open another connection will block and error with: java.sql.SQLException: Lock wait timeout exceeded; try restarting transaction.
Instead test if there is a connection already open and don't open another if there is one present.
