### PR TITLE
korma.core/exec has been declared dynamic, in this way it is possible to...

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -454,7 +454,7 @@
         query))
     query))
 
-(defn exec
+(defn ^:dynamic exec
   "Execute a query map and return the results."
   [query]
   (let [query (apply-prepares query)


### PR DESCRIPTION
... rebind it to wrap some middleware around it, even if you are using the macro variants of select, insert etc. in korma.core.

Best regards

Max
