### PR TITLE
support for modifiers in insert query

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -304,9 +304,11 @@
         keys-clause (utils/comma-separated (map field-identifier ins-keys))
         ins-values (insert-values-clause ins-keys (:values query))
         values-clause (utils/comma-separated ins-values)
+        modifiers-clause (when (seq (:modifiers query))
+                           (str (reduce str (:modifiers query)) " "))
         neue-sql (if-not (empty? ins-keys)
-                   (str "INSERT INTO " (table-str query) " " (utils/wrap keys-clause) " VALUES " values-clause)
-                   noop-query)]
+                   (str "INSERT " modifiers-clause "INTO " (table-str query) " " (utils/wrap keys-clause) " VALUES " values-clause)
+                   noop-query)]        
     (assoc query :sql-str neue-sql)))
 
 ;;*****************************************************


### PR DESCRIPTION
Added support for modifiers in insert query.
Useful e.g. in mysql for
INSERT IGNORE INTO ...

Just a copy-paste from sql-select now, but maybe there should be some generalization to support modifiers in all types of queries? 
