### PR TITLE
s/identifier/entity/ in ->naming-strategy

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -210,7 +210,7 @@
 
 (defn- ->naming-strategy [{:keys [keys fields]}]
   {:keyword keys
-   :identifier fields})
+   :entity fields})
 
 (defmacro with-db
   "Execute all queries within the body using the given db spec"


### PR DESCRIPTION
clojure.java.jdbc expects :entity not :identifier see: https://github.com/clojure/java.jdbc/blob/java.jdbc-0.2.3/src/main/clojure/clojure/java/jdbc.clj#L288
