### PR TITLE
introducing alias-delimiter option to let users decide what word will be used for alias

### DIFF
--- a/src/korma/config.clj
+++ b/src/korma/config.clj
@@ -2,7 +2,8 @@
 
 (defonce options (atom {:delimiters ["\"" "\""]
                         :naming {:fields identity
-                        :keys identity}}))
+                                 :keys identity}
+                        :alias-delimiter " AS "}))
 
 (defn- ->delimiters [cs]
   (if cs
@@ -16,9 +17,10 @@
           :fields identity}
          strategy))
 
-(defn extract-options [{:keys [naming delimiters subprotocol]}]
+(defn extract-options [{:keys [naming delimiters subprotocol alias-delimiter]}]
   {:naming (->naming naming)
    :delimiters (->delimiters delimiters)
+   :alias-delimiter (or alias-delimiter " AS ")
    :subprotocol subprotocol})
 
 (defn set-delimiters

--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -97,7 +97,8 @@
 
 (defn alias-clause [alias]
   (when alias
-    (str " AS " (delimit-str (name alias)))))
+    (str (:alias-delimiter (or *bound-options* @conf/options))
+         (delimit-str (name alias)))))
 
 (defn field-str [v]
     (let [[fname alias] (if (vector? v)

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -7,11 +7,16 @@
 
 (defdb test-db-opts (postgres {:db "korma" :user "korma" :password "kormapass" :delimiters "" :naming {:fields string/upper-case}}))
 (defdb test-db (postgres {:db "korma" :user "korma" :password "kormapass"}))
+(defdb test-db-alias (postgres {:db "korma" :user "korma" :password "kormapass" :alias-delimiter " "}))
 
 (defdb mem-db (h2 {:db "mem:test"}))
 
 (defentity delims
   (database test-db-opts))
+
+(defentity alias-entity
+  (table :alias :a)
+  (database test-db-alias))
 
 (defentity users)
 (defentity state)
@@ -304,6 +309,18 @@
   (sql-only
     (is (= "SELECT DELIMS.* FROM DELIMS"
            (select delims)))))
+
+(deftest alias-delimiter-options
+  (sql-only
+    (is (= "SELECT \"a\".* FROM \"alias\" \"a\""
+           (select alias-entity)))))
+
+(deftest alias-delimiter-options-with-fields
+  (sql-only
+    (is (= "SELECT \"a\".\"foo\" \"a\", \"a\".\"bar\" \"b\" FROM \"alias\" \"a\""
+           (select
+            alias-entity
+            (fields [:foo :a] [:bar :b]))))))
 
 (deftest false-set-in-update
   (sql-only


### PR DESCRIPTION
After #116 was merged, #23 happened again because oracle doesn't support "AS" as alias.
This fix will let users specify it in database configuration.
