### PR TITLE
Fix for Issue 186 - Replace ref to `table-fields` in README with `entity-fields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ And include log4j in your project.clj:
 
 
 (defentity address
- (table-fields :street :city :zip))
+ (entity-fields :street :city :zip))
 
 (defentity users
  (has-one address))


### PR DESCRIPTION
`table-fields` doesn't exist anymore, and so trying out Korma using the README documentation results in errors.

The function was replaced by `entity-fields` in commit d75d1e1f70a14940809e1a6722e5879d2e7bbb96, this PR just changes the README to match the code.
