### PR TITLE
Passing through JDBC options.

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -395,6 +395,26 @@
   [s]
   (utils/generated s))
 
+(defn fetch-size
+  "Sets the JDBC fetch size for this query, i.e. the number of rows pulled back
+  with each round trip to the server. Fetch size defaults to 10 on most drivers.
+  This option will not affect which rows are returned, but if you are running
+  big queries then turning fetch size up (e.g. to 1000) can make them finish much faster.
+
+  (select users
+    (fetch-size 1000))"
+  [query fs]
+  (assoc-in query [:jdbc-options :fetch-size] fs))
+
+(defn max-rows
+  "Sets the JDBC max rows option. Useful as an alternative to (limit) for DBMSs that do
+  not support LIMIT (e.g. Oracle).
+
+  (select users
+    (max-rows 10))"
+  [query mr]
+  (assoc-in query [:jdbc-options :max-rows] mr))
+
 ;;*****************************************************
 ;; Query exec
 ;;*****************************************************

--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -210,11 +210,15 @@
       (jdbc/print-sql-exception e)))
   (throw e))
 
-(defn- exec-sql [{:keys [results sql-str params]}]
+(defn- exec-sql [{:keys [results sql-str params jdbc-options]}]
   (try
     (case results
-      :results (jdbc/with-query-results rs (apply vector sql-str params)
-                 (vec rs))
+      :results (jdbc/with-query-results
+                  rs
+                  (if jdbc-options
+                    (apply vector jdbc-options sql-str params)
+                    (apply vector sql-str params))
+                  (vec rs))
       :keys (jdbc/do-prepared-return-keys sql-str params)
       (jdbc/do-prepared sql-str params))
     (catch Exception e

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -305,6 +305,14 @@
            (select user2))))
   (set-delimiters "\""))
 
+(deftest jdbc-options
+  (is (= {:fetch-size 1000}
+         (:jdbc-options (query-only (select users (fetch-size 1000))))))
+  (is (= {:max-rows 10}
+         (:jdbc-options (query-only (select users (max-rows 10))))))
+  (is (= {:fetch-size 1 :max-rows 2}
+         (:jdbc-options (query-only (select users (fetch-size 1) (max-rows 2)))))))
+
 (deftest naming-delim-options
   (sql-only
     (is (= "SELECT DELIMS.* FROM DELIMS"


### PR DESCRIPTION
Added functionality to set and pass through two JDBC options (:fetch-size and :max-rows) to clojure.java.jdbc's prepare-statement.

Fetch size is important because large queries to a remote server are intolerably slow with the default fetch size of 10.

Max rows is important because the only simple way Korma currently provides to limit the number of rows returned is the (limit) function, which relies on SQL LIMIT, which is not supported by Oracle. The only workaround my group was able to find was to run our original query as a subselect, then call (where (raw (str "rownum <= " X))), but this has the problem of not automatically calling any transforms defined for entities in the subselect. Being able to call (select users (max-rows X)) solves this.

Some usage examples, with performance for one of the large tables my group uses:

user=> (defdb b (korma.db/oracle {...}}))
{:pool …}
user=> (defentity ent (table ...))
# 'user/ent

user=> (count (time (select ent (fields :name))))
"Elapsed time: 14443.238 msecs"
17178
user=> (count (time (select ent (fields :name))))
"Elapsed time: 14247.032 msecs"
17178
user=> (count (time (select ent (fields :name))))
"Elapsed time: 14024.118 msecs"
17178
user=> (count (time (select ent (fields :name) (fetch-size 100))))
"Elapsed time: 1812.418 msecs"
17178
user=> (count (time (select ent (fields :name) (fetch-size 1000))))
"Elapsed time: 353.63 msecs"
17178

user=> (count (time (select ent (fields :name) (max-rows 100))))
"Elapsed time: 160.334 msecs"
100
user=> (count (time (select ent (fields :name) (limit 100)))) ;;Oracle doesn't support LIMIT.
Failure to execute query with SQL:
SELECT “TABLE_NAME.”NAME" FROM “TABLE_NAME” LIMIT 100  ::  []
SQLSyntaxErrorException:
 Message: ORA-00933: SQL command not properly ended

 SQLState: 42000
 Error Code: 933

SQLSyntaxErrorException ORA-00933: SQL command not properly ended
  oracle.jdbc.driver.T4CTTIoer.processError (T4CTTIoer.java:445)
