### PR TITLE
Fixed entity-fields issue #157

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -36,19 +36,21 @@
          (merge ~'this-query ~m)))))
 
 (defn select* 
-  "Create an empty select query. Ent can either be an entity defined by defentity,
+  "Create a select query with fields provided in Ent.  If fields are not provided,
+  create an empty select query. Ent can either be an entity defined by defentity,
   or a string of the table name"
   [ent]
-  (make-query ent {:type :select
-                   :fields [::*]
-                   :from [(:ent this-query)]
-                   :modifiers []
-                   :joins []
-                   :where []
-                   :order []
-                   :aliases #{}
-                   :group []
-                   :results :results}))
+  (let [default-fields (not-empty (:fields ent))]
+    (make-query ent {:type :select
+                     :fields (or default-fields [::*])
+                     :from [(:ent this-query)]
+                     :modifiers []
+                     :joins []
+                     :where []
+                     :order []
+                     :aliases #{}
+                     :group []
+                     :results :results})))
 
 (defn update* 
   "Create an empty update query. Ent can either be an entity defined by defentity,
@@ -607,7 +609,7 @@
   "Set the fields to be retrieved by default in select queries for the
   entity."
   [ent & fields]
-  (update-in ent [:fields] utils/vconcat (map #(eng/prefix ent %) fields)))
+  (update-in ent [:fields] utils/vconcat fields))
 
 (defn table
   "Set the name of the table and an optional alias to be used for the entity. 

--- a/test/korma/test/connected.clj
+++ b/test/korma/test/connected.clj
@@ -40,22 +40,14 @@
 (defentity user
   (table :users)
   (has-many address {:fk :user-id})
-  (entity-fields
-   :name :age)
-
   (transform
    #(update-in % [:address] (partial sort-by :id))))
 
 (defentity address
   (belongs-to user {:fk :user-id})
-  (belongs-to state)
-  
-  (entity-fields
-   :number :street :city :zip))
+  (belongs-to state))
 
-(defentity state
-  (entity-fields
-   :name))
+(defentity state)
 
 (def initial-data
   {:state

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -32,6 +32,10 @@
 (defentity users-alias
   (table :users :u))
 
+(defentity users-with-entity-fields
+  (table :users)
+  (entity-fields :id :username))
+
 (defentity ^{:private true} blah (pk :cool) (has-many users {:fk :cool_id}))
 
 (deftest test-defentity-accepts-metadata
@@ -55,6 +59,8 @@
          "SELECT \"users\".* FROM \"users\""
          (select users-alias)
          "SELECT \"u\".* FROM \"users\" AS \"u\""
+         (select users-with-entity-fields)
+         "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
          (select users
                  (fields :id :username))
          "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
@@ -507,12 +513,10 @@
 (declare mtm1 mtm2)
 
 (defentity mtm1
-  (entity-fields :field1)
   (many-to-many mtm2 :mtm1_mtm2 {:lfk :mtm1_id
                                  :rfk :mtm2_id}))
 
 (defentity mtm2
-  (entity-fields :field2)
   (many-to-many mtm1 :mtm1_mtm2 {:lfk :mtm2_id
                                  :rfk :mtm1_id}))
 
@@ -553,11 +557,9 @@
 (declare mtmdk1 mtmdk2)
 
 (defentity mtmdk1
-  (entity-fields :field1)
   (many-to-many mtmdk2 :mtmdk1_mtmdk2))
 
 (defentity mtmdk2
-  (entity-fields :field2)
   (many-to-many mtmdk1 :mtmdk1_mtmdk2))
 
 (deftest many-to-many-default-keys


### PR DESCRIPTION
- Entity-fields simplified to only accept fields for that particular entity.
  This removes the ability to specify related table fields by default, which
  I'd consider more reasonable behavior.
- Fields are added during select\* if they exist in the entity map. Otherwise, all (*).

Fixed failing tests and added specific entity-fields test

Tests utilizing entity-fields were passing previously because entity-fields
was not working (i.e. not providing default fields for SELECT).  Many tests
failed after applying the bug fix because they expected \* (all) fields.
So, 'entity-fields' was removed from entities that were not explicitly
testing that functionality and a new simple select case was added.
