### PR TITLE
Added clob-to-str to sql.utils 

### DIFF
--- a/src/korma/sql/utils.clj
+++ b/src/korma/sql/utils.clj
@@ -67,6 +67,6 @@
 ;; clob-utils
 ;;*****************************************************
 
-(defn clob-to-string [clob]
+(defn clob-to-str [clob]
   (with-open [rdr (java.io.BufferedReader. (.getCharacterStream clob))]
     (apply str (line-seq rdr))))

--- a/src/korma/sql/utils.clj
+++ b/src/korma/sql/utils.clj
@@ -62,3 +62,11 @@
 
 (defn vconcat [v1 v2]
   (vec (concat v1 v2)))
+
+;;*****************************************************
+;; clob-utils
+;;*****************************************************
+
+(defn clob-to-string [clob]
+  (with-open [rdr (java.io.BufferedReader. (.getCharacterStream clob))]
+    (apply str (line-seq rdr))))


### PR DESCRIPTION
This would be useful when dealing with JdbcClob fields. 

Example:

``` clojure
(ns shoebox.models.photo
  (:require [korma.sql.utils :as utils]))

(defentity photos
  (transform (fn [{metadata :metadata :as v}]
               (if metadata
                 (assoc v :metadata (utils/clob-to-str metadata)) v))))
```
