### PR TITLE
Fix typo in one to one integration test

### DIFF
--- a/test/korma/test/integration/one_to_one.clj
+++ b/test/korma/test/integration/one_to_one.clj
@@ -21,7 +21,7 @@
 
 (def schema
   ["drop table if exists \"state\";"
-   "drop table if exists \"users\";"
+   "drop table if exists \"user\";"
    "drop table if exists \"address\";"
    "create table \"state\" (\"state_id\" varchar(20),
                          \"name\" varchar(100));"


### PR DESCRIPTION
I don't think this actually made a difference, but the test was dropping `users` and creating `user`.
