### PR TITLE
Add reorder function

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -277,6 +277,15 @@
   [query field & [dir]]
   (update-in query [:order] conj [field (or dir :ASC)]))
 
+(defn reorder
+  "Clear all order clauses then add an ORDER BY clause to a select, union,
+  union-all or intersect query.
+  field should be a keyword of the field name, dir is ASC by default.
+  
+  (reorder query :created :asc)"
+  [query field & [dir]]
+  (order (assoc query :order []) field dir))
+
 (defn values
   "Add records to an insert clause. values can either be a vector of maps or a
   single map.

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -188,6 +188,13 @@
         "SELECT \"users\".* FROM \"users\""
         (select users (where {})))))
 
+(deftest order-reorder
+  (sql-only
+    (is (= "SELECT \"users\".* FROM \"users\" ORDER BY \"users\".\"created\" DESC"
+           (select users
+                   (order :updated)
+                   (reorder :created :DESC))))))
+
 (deftest with-many
   (with-out-str
     (dry-run


### PR DESCRIPTION
This pull-request adds a `reorder` function similar to the existing `order` function, however, it first clears any existing order clauses.

Example:

``` clojure
(def query (-> (select* users)
               (order :foo)
               (order :bar)))

(exec (-> query
          (reorder :created))
```

This results in the following SQL:

``` sql
SELECT "users".* FROM "users" ORDER BY "users"."created" ASC
```

---

As another example, consider the case where we have a sorted base query that we'd like to return along with the total count.  In the following case the `reorder` is actually necessary (otherwise the count query fails).

``` clojure
(def query (-> (select* users)
               (where {:username [= "foo"])
               (order :created)))

(def results (-> query
                 (limit 10)
                 (offset 25)))

(def total (-> query
               (aggregate (count :*) :total)
               (reorder :total)))
```
