### PR TITLE
dependencies status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Tasty SQL for Clojure.
 ## TravisCI Status
 
 [![Build Status](https://travis-ci.org/korma/Korma.png)](https://travis-ci.org/korma/Korma)
+[![Dependencies Status](http://jarkeeper.com/korma/Korma/status.png)](http://jarkeeper.com/korma/Korma)
 
 ## Getting started
 


### PR DESCRIPTION
Hi,

I'm an author of jarkeeper. It generates badge for Clojure libraries and show if they have up-to-date dependencies.

Here is the page for Korma: http://jarkeeper.com/korma/Korma.

What do you think about it?