### PR TITLE
Fixes issue with thread-safety on with-db

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -687,7 +687,7 @@
                     (update-in [:group] #(force-prefix sub-ent %))))))
 
 (defn assoc-db-to-entity [ent]
-  (assoc ent :db (or (:db ent) (assoc @db/_default :options @korma.config/options))))
+  (assoc ent :db (or (:db ent) (assoc (or db/*current-db* @db/_default) :options @korma.config/options))))
 
 (defn- with-one-to-many [rel query ent body-fn]
   (let [fk-key (:fk-key rel)

--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -6,6 +6,8 @@
 
 (defonce _default (atom nil))
 
+(def ^:dynamic *current-db* nil)
+
 (defn default-connection
   "Set the database connection that Korma should use by default when no
   alternative is specified."
@@ -244,17 +246,14 @@
 (defmacro with-db
   "Execute all queries within the body using the given db spec"
   [db & body]
-  `(let [connection# @_default]
-     (try
-       (default-connection ~db)
-       ~@body
-       (finally
-         (default-connection connection#)))))
+  `(binding [*current-db* ~db]
+     (jdbc/with-connection (korma.db/get-connection ~db)
+       ~@body)))
 
 (defn do-query [{:keys [db options] :as query}]
   (let [options (or options @conf/options)]
     (jdbc/with-naming-strategy (->naming-strategy (:naming options))
       (if (jdbc/find-connection)
         (exec-sql query)
-        (jdbc/with-connection (get-connection (or db @_default))
+        (with-db (or db @_default)
           (exec-sql query))))))

--- a/test/korma/test/integration/helpers.clj
+++ b/test/korma/test/integration/helpers.clj
@@ -20,6 +20,9 @@
 (defn mem-db []
   (kdb/create-db (kdb/h2 {:db "mem:korma_test"})))
 
+(defn mem-db-2 []
+  (kdb/create-db (kdb/h2 {:db "mem:korma_test_2"})))
+
 (defmacro with-delimiters [& body]
   `(let [delimiters# (:delimiters @kconfig/options)]
      (try

--- a/test/korma/test/integration/with_db.clj
+++ b/test/korma/test/integration/with_db.clj
@@ -4,6 +4,7 @@
             [criterium.core :as cr]
             [korma.core :as kcore]
             [korma.db :as kdb])
+  (:import [java.util.concurrent Executors ThreadPoolExecutor CountDownLatch])
   (:use clojure.test
         korma.test.integration.helpers))
 
@@ -22,7 +23,46 @@
                                       (kcore/select user (kcore/with address)))))))))
 
 (deftest with-db-success
-  (testing "with-db with setting @_default in with-db binding"
+  (testing "with-db with setting *current-db* in with-db binding"
     (is (> (count (:address (first (kdb/with-db (mem-db)
                                      (with-naming dash-naming-strategy
                                        (kcore/select user (kcore/with address)))))))) 1)))
+
+(defn delete-some-rows-from-db []
+  (kcore/delete address))
+
+(deftest thread-safe-with-db
+  (testing "kdb/with-db using binding"
+    (let [db1 (mem-db)
+          db2 (mem-db-2)]
+      ;; let's create some records in the first db
+      (kdb/with-db db1 (populate 2))
+
+      ;; let's create some records in the second db
+      (kdb/with-db db2 (populate 2))
+
+      (kdb/default-connection db1)
+
+      ;; we will create 2 threads and execute them at the same time
+      ;; using a CountDownLatch to synchronize their execution
+      (let [latch (CountDownLatch. 2)
+            t1 (future (kdb/with-db db2
+                      (.countDown latch)
+                      (.await latch)
+                      (delete-some-rows-from-db)))
+            t2 (future (kdb/with-db db1
+                      (.countDown latch)
+                      (.await latch)
+                      (delete-some-rows-from-db)))]
+        @t1
+        @t2
+        (.await latch))
+
+      (kdb/default-connection nil)
+
+      (let [addresses-mem-db-1 (kdb/with-db db1
+                                 (kcore/select address))
+            addresses-mem-db-2 (kdb/with-db db2
+                                 (kcore/select address))]
+        (is (= (count addresses-mem-db-1) 0))
+        (is (= (count addresses-mem-db-2) 0))))))


### PR DESCRIPTION
I've added 2 tests to the integration test with-db

The tests:
1.  verify that the version of the with-db I wrote to fix lazyness broke thread safety on the with-db macro.  
2.  verify that my new version fixes the thread safety issue.

Let me know what you think of this.
