### PR TITLE
Don't override C3P0 system properties with defaults

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -21,14 +21,14 @@
            idle-connection-test-period
            test-connection-on-checkin
            test-connection-on-checkout]
-    :or {excess-timeout (* 30 60)
-         idle-timeout (* 3 60 60)
-         minimum-pool-size 3
-         maximum-pool-size 15
-         test-connection-query nil
-         idle-connection-test-period 0
-         test-connection-on-checkin false
-         test-connection-on-checkout false}
+    :or {excess-timeout (Integer/getInteger "c3p0.maxIdleTimeExcessConnections" (* 30 60))
+         idle-timeout (Integer/getInteger "c3p0.maxIdleTime" (* 3 60 60))
+         minimum-pool-size (Integer/getInteger "c3p0.minPoolSize" 3)
+         maximum-pool-size (Integer/getInteger "c3p0.maxPoolSize" 15)
+         test-connection-query (System/getProperty "c3p0.preferredTestQuery")
+         idle-connection-test-period (Integer/getInteger "c3p0.idleConnectionTestPeriod" 0)
+         test-connection-on-checkin (Boolean/getBoolean "c3p0.testConnectionOnCheckin")
+         test-connection-on-checkout (Boolean/getBoolean "c3p0.testConnectionOnCheckout")}
     :as spec}]
   {:datasource (doto (ComboPooledDataSource.)
                  (.setDriverClass classname)


### PR DESCRIPTION
Korma gives you a way to configure C3P0's [ComboPooledDataSource](http://www.mchange.com/projects/c3p0/apidocs/com/mchange/v2/c3p0/ComboPooledDataSource.html), but only sets a handful of the configurable parameters. C3P0 has a set of [configuration properties](http://www.mchange.com/projects/c3p0/#configuration_properties) that ComboPooledDataSource will use as defaults.

The issue is that Korma also applies defaults, in [korma.db/connection-pool](https://github.com/korma/Korma/blob/f66404cdc8abfc4614532eb2fb83780786f933cb/src/korma/db.clj#L18), which override the system properties that your app may have set.

As such, when your application wants to configure the pool at runtime, using a mix of some of the configuration that has Korma defaults and some that does not, it needs to include some logic for adding the Korma-controlled config into the database spec for the subset of system properties that Korma would otherwise effectively overwrite.

This patch makes Korma use C3P0 configuration properties, then fall back to its own defaults.