### PR TITLE
Add support for joining entities, using a specific join-type

### DIFF
--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -256,6 +256,18 @@
           (select user2
                   (join address))))))
 
+(deftest left-join-ent-directly
+  (sql-only
+   (is (= "SELECT \"users\".* FROM \"users\" LEFT JOIN \"address\" ON \"users\".\"id\" = \"address\".\"users_id\""
+          (select user2
+                  (join :left address))))))
+
+(deftest inner-join-ent-directly
+  (sql-only
+   (is (= "SELECT \"users\".* FROM \"users\" INNER JOIN \"address\" ON \"users\".\"id\" = \"address\".\"users_id\""
+          (select user2
+                  (join :inner address))))))
+
 (deftest new-with
   (sql-only
    (are [result query] (= result query)


### PR DESCRIPTION
Currently, it is possible to specify a type (e.g. :inner) when doing a join 
with an explicit clause 

``` clojure
(select "users" (join :inner "email" (= :email.users_id :id)))
```

When joining entities based on their <b>relation</b> as below, the type is defaulted to :left

``` clojure
(select users (join email))
```

And it is not possible specify a type, i.e. not possible to do

``` clojure
(select users (join :inner email))
```

I've enabled this and made the change so that the arglists look like so

``` clojure
[query ent]
[query type ent] ;new
[query table clause]
[query type table clause]
```

I believe this is very helpful as it allows us to join entities using an arbitrary join-type, without having to repeat the join constraints from the rels that we already defined in defentity.  
