### PR TITLE
Add initial-pool-size config to c3p0 configs

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -19,13 +19,15 @@
 (defn connection-pool
   "Create a connection pool for the given database spec."
   [{:keys [subprotocol subname classname user password
-           excess-timeout idle-timeout minimum-pool-size maximum-pool-size
+           excess-timeout idle-timeout
+           initial-pool-size minimum-pool-size maximum-pool-size
            test-connection-query
            idle-connection-test-period
            test-connection-on-checkin
            test-connection-on-checkout]
     :or {excess-timeout (* 30 60)
          idle-timeout (* 3 60 60)
+         initial-pool-size 3
          minimum-pool-size 3
          maximum-pool-size 15
          test-connection-query nil
@@ -40,6 +42,7 @@
                  (.setPassword password)
                  (.setMaxIdleTimeExcessConnections excess-timeout)
                  (.setMaxIdleTime idle-timeout)
+                 (.setInitialPoolSize initial-pool-size)
                  (.setMinPoolSize minimum-pool-size)
                  (.setMaxPoolSize maximum-pool-size)
                  (.setIdleConnectionTestPeriod idle-connection-test-period)

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -24,6 +24,7 @@
    :subname "mem:db_connectivity_test_db"
    :excess-timeout 99
    :idle-timeout 88
+   :initial-pool-size 10
    :minimum-pool-size 5
    :maximum-pool-size 20
    :test-connection-on-checkout true
@@ -48,6 +49,7 @@
         datasource (:datasource pool)]
     (is (= 99 (.getMaxIdleTimeExcessConnections datasource)))
     (is (= 88 (.getMaxIdleTime datasource)))
+    (is (= 10 (.getInitialPoolSize datasource)))
     (is (= 5 (.getMinPoolSize datasource)))
     (is (= 20 (.getMaxPoolSize datasource)))
     (is (= (:test-connection-query db-config-with-options-set) (.getPreferredTestQuery datasource)))


### PR DESCRIPTION
Being able to configure the initial pool size in c3p0 is pretty convenient and I'd love to be able to expose that through Korma. For reference: http://www.mchange.com/projects/c3p0/#initialPoolSize

Please note that I have no idea how to run the UTs on this project, so let me know if there's a straightforward way of trying that out. I ran the full UT suite of our API using this custom version of Korma and had no trouble and was able to verify intended behavior.
