### PR TITLE
Key naming strategy not used during one-to-one-later joins

### DIFF
--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -387,13 +387,13 @@
        "SELECT \"state\".* FROM \"state\" WHERE EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND \"address\".\"state_id\" = \"state\".\"id\")))"
        (sql-only
          (select state
-                 (where (exists (subselect address 
+                 (where (exists (subselect address
                                            (where (and {:id [> 5]} (= :state_id :state.id))))))))
 
        "SELECT \"state\".* FROM \"state\" WHERE (EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND \"address\".\"state_id\" = \"state\".\"id\"))) AND NOT(EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" < ?) OR \"address\".\"state_id\" <> \"state\".\"id\")))))"
        (sql-only
          (select state
-                 (where (and (exists (subselect address 
+                 (where (and (exists (subselect address
                                            (where (and {:id [> 5]} (= :state_id :state.id)))))
                              (not (exists (subselect address
                                            (where (or  {:id [< 10]} (not= :state_id :state.id))))))))))
@@ -401,8 +401,8 @@
        "SELECT \"state\".* FROM \"state\" WHERE EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND NOT(EXISTS((SELECT \"users\".* FROM \"users\" WHERE \"address\".\"user_id\" = \"users\".\"id\"))))))"
        (sql-only
          (select state
-                 (where (exists (subselect address 
-                                           (where (and {:id [> 5]} 
+                 (where (exists (subselect address
+                                           (where (and {:id [> 5]}
                                                        (not (exists (subselect user2 (where (= :address.user_id :id))))))))))))
 
        "SELECT \"users\".* FROM \"users\", (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) AS \"u2\""
@@ -747,3 +747,24 @@
                              (with address-with-db
                                    (where {:status 1}))
                              (order :id)))))))
+
+
+;;****************************************************
+;; Field naming and belongs-to mapping
+;;****************************************************
+(defdb with-naming-db (mysql {:naming {:keys (comp keyword clojure.string/upper-case name)}}))
+
+(declare user4)
+
+(defentity address4
+  (database with-naming-db)
+  (transform identity)
+  (belongs-to user4))
+
+(defentity user4
+  (database with-naming-db)
+  (has-many address4))
+
+(deftest test-belongs-to-with-key-naming-fn-for-subentity
+  (is (= {:ID 1 :USER4_ID 1 :ID_2 1 :USER_MARKER 1}
+         (first (dry-run (select address4 (with user4 (fields :USER_MARKER))))))))


### PR DESCRIPTION
I ran into a problem where my belongs-to joins were not working as expected. After some investigation, I narrowed it down to the fact that the following conditions had to be in place to cause the issue:
- Using a transform on the child entity
- Using a key-naming strategy on the database

Having the transform on the child entity meant that the one-to-one (belongs-to) mapping was performed "later" (in the ```korma.core/with-one-to-one-later``` function), but when combined with a key naming strategy the "join" was not working, as the generated foreign key name had not had the naming strategy applied, and thus could never be found in the parent entity result map.

I created a quick and dirty gist to try and explain the conditions to trigger the problem: https://gist.github.com/bbbates/c3e13f65bb37518b0865
