### PR TITLE
Fix lazy namespace resolution of relations.

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -571,10 +571,10 @@
 
 (defn rel [ent sub-ent type opts]
   (let [var-name (-> sub-ent meta :name)
-        cur-ns *ns*]
+        var-ns (-> sub-ent meta :ns)]
     (assoc-in ent [:rel (name var-name)]
               (delay
-               (let [resolved (ns-resolve cur-ns var-name)
+               (let [resolved (ns-resolve var-ns var-name)
                      sub-ent (when resolved (deref sub-ent))]
                  (when-not (map? sub-ent)
                    (throw (Exception. (format "Entity used in relationship does not exist: %s" (name var-name)))))

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -34,6 +34,13 @@
   (has-one address)
   (has-many email))
 
+(create-ns 'f)
+(intern 'f 'friend (create-entity "friend"))
+
+(defentity users-with-friend
+  (table :users)
+  (has-one f/friend))
+
 (defentity users-alias
   (table :users :u))
 
@@ -66,6 +73,8 @@
          "SELECT \"u\".* FROM \"users\" AS \"u\""
          (select users-with-entity-fields)
          "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
+         (select users-with-friend (with f/friend))
+         "SELECT \"users\".*, \"friend\".* FROM \"users\" LEFT JOIN \"friend\" ON \"friend\".\"users_id\" = \"users\".\"id\""
          (select users
                  (fields :id :username))
          "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""


### PR DESCRIPTION
Earlier the relations used lazy entity resolving from the current namespace, but
they should be resolve the entity from the original namespace instead. Otherwise
it is possible that if an entity is created dynamically in a different namespace
than where it is used, it fails to resolve the referred entities.

For more information and a test case see the mailing list post at https://groups.google.com/forum/#!topic/sqlkorma/Qfr7szJUFdo