### PR TITLE
De-resolve predicate symbols before looking them up

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -210,7 +210,7 @@
   (let [[func value] (if (vector? v)
                        v
                        [pred-= v])
-        pred? (predicates func)
+        pred? (predicates (symbol (name func)))
         func (if pred?
                (resolve pred?)
                func)]


### PR DESCRIPTION
Use `name` to de-resolve predicate symbols (ie, turn `'clojure.core/=`
into `'=`), which allows passing predicates that have been resolved by
syntax-quote to `where`, `join`, etc.

Fixes #287