### PR TITLE
enable to specify extra queries of JDBC URL

### DIFF
--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -45,7 +45,7 @@
 (defn- setup-korma-db []
   (jdbc/db-do-commands mysql-uri "CREATE DATABASE IF NOT EXISTS korma;"
                                  "USE korma;"
-                                 "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200));"))
+                                 "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin');"))
 
 (defn- clean-korma-db []
   (jdbc/db-do-commands mysql-uri "DROP DATABASE korma;"))
@@ -66,3 +66,14 @@
   (sql-only
    (is (= (update users-mysql (set-fields {:field "value"}))
           "UPDATE `users-mysql` SET `field` = ?"))))
+
+(deftest test-non-ascii-character
+  (setup-korma-db)
+  (defdb live-db-mysql (mysql {:db "korma" :user "root" :properties {"useUnicode" true "characterEncoding" "utf8"}}))
+  (defentity users-live-mysql (database live-db-mysql))
+
+  (insert users-live-mysql (values {:name "コーマ"})) ; "コーマ" is "Korma" in Japanese
+  (is (= '({:name "コーマ"})
+         (select users-live-mysql)))
+
+  (clean-korma-db))


### PR DESCRIPTION
Improved #259 and #227.

I have added the `:extra` option into `korma.db/connection-pool` and a test case for handling non-ascii characters.

Extra queries are useful for passing properties to JDBC.

Especially, to make MySQL support  non-ascii characters, I have to append queries (e.g. `?useUnicode=true&characterEncoding=utf8`) to JDBC URL.

I have tested this PR on MySQL(MariaDB) and PostgreSQL. I couldn't test on other databases,

Thanks.