### PR TITLE
added support for postgresql default schema

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -114,12 +114,12 @@
   "Create a database specification for a postgres database. Opts should include
   keys for :db, :user, and :password. You can also optionally set host and
   port."
-  [{:keys [host port db make-pool?]
-    :or {host "localhost", port 5432, db "", make-pool? true}
+  [{:keys [host port db default-schema make-pool?]
+    :or {host "localhost", port 5432, db "", default-schema "", make-pool? true}
     :as opts}]
   (merge {:classname "org.postgresql.Driver" ; must be in classpath
           :subprotocol "postgresql"
-          :subname (str "//" host ":" port "/" db)
+          :subname (str "//" host ":" port "/" db (if (not (empty? default-schema)) (str "?searchpath=" default-schema)))
           :make-pool? make-pool?}
          opts))
 

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -106,6 +106,20 @@
            (postgres {:host "host"
                       :port "port"
                       :db "db"
+                      :make-pool? false}))))
+  (testing "postgres - options selected with default schema"
+    (is (= {:db "db"
+            :port "port"
+            :host "host"
+            :classname "org.postgresql.Driver"
+            :subprotocol "postgresql"
+            :subname "//host:port/db?searchpath=schema"
+            :default-schema "schema"
+            :make-pool? false}
+           (postgres {:host "host"
+                      :port "port"
+                      :db "db"
+                      :default-schema "schema"
                       :make-pool? false})))))
 
 (deftest test-oracle


### PR DESCRIPTION
this allows to choose a default schema to a connection. once set, you don't need to specify schema (table) when you use defentity.

It depends on a postgres searchpath parameter to the connection url.