### PR TITLE
order no longer accepts varargs arguments as that only hides bugs in …

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -280,8 +280,10 @@
   field should be a keyword of the field name, dir is ASC by default.
 
   (order query :created :asc)"
-  [query field & [dir]]
-  (update-in query [:order] conj [field (or dir :ASC)]))
+  ([query field dir]
+    (update-in query [:order] conj [field (or dir :ASC)]))
+  ([query field]
+    (order query field :ASC)))
 
 (defn values
   "Add records to an insert clause. values can either be a vector of maps or a


### PR DESCRIPTION
…the user code.

Specifically, the before the change, following code produces perfectly legal SQL:
```
(sql/select t
    (sql/order :a :ASC :b :ASC))
```
However, the ordering doesn't work as intended. Korma just takes :ASC and skips the rest. This will hide bugs in the user's code as sometimes the order of records happens to be correct by accident.

After the change, this example code won't compile. This means that certain users need to fix their code if this is merged to Korma. But as their code is broken at the moment, I believe it is a good thing. The fix is straightforward:

The example written properly:
```
(sql/select t
    (sql/order :a :ASC)
    (sql/order :b :ASC)
```

It might be better, but also more complicated, to alter ```order``` to deal with multiple fields properly. That too would break some programs, albeit in a different manner, as broken code would suddenly produce different SQL.
