### PR TITLE
Changes to use fk option on korma.core/get-db-keys and korma.core/db-keys-and-foreign-ent

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -548,8 +548,8 @@
    :rpk (raw (eng/prefix child (:pk child)))
    :join-table join-table})
 
-(defn- get-db-keys [parent child]
-  (let [fk-key (default-fk-name parent)]
+(defn- get-db-keys [parent child {:keys [fk]}]
+  (let [fk-key (or fk (default-fk-name parent))]
     {:pk (raw (eng/prefix parent (:pk parent)))
      :fk (raw (eng/prefix child fk-key))
      :fk-key fk-key}))
@@ -557,8 +557,8 @@
 (defn- db-keys-and-foreign-ent [type ent sub-ent opts]
   (case type
     :many-to-many        [(many-to-many-keys ent sub-ent opts) sub-ent]
-    (:has-one :has-many) [(get-db-keys ent sub-ent) sub-ent]
-    :belongs-to          [(get-db-keys sub-ent ent) ent]))
+    (:has-one :has-many) [(get-db-keys ent sub-ent opts) sub-ent]
+    :belongs-to          [(get-db-keys sub-ent ent opts) ent]))
 
 (defn create-relation [ent sub-ent type opts]
   (let [[db-keys foreign-ent] (db-keys-and-foreign-ent type ent sub-ent opts)

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -484,6 +484,20 @@
        (sql-only
         (select subsel))))
 
+(deftest entity-with-belongs-to-subselect
+ (defentity subsel
+  (pk :subsel_id)
+  (table  (subselect "test") :subseltest))
+  (defentity ent
+   (table :ent)
+   (pk :ent_id)
+   (belongs-to subsel  {:fk :subsel_ent_id}))
+  (are  [result query]  (= result query)
+   "SELECT \"ent\".*, \"subseltest\".* FROM \"ent\" LEFT JOIN (SELECT \"test\".* FROM \"test\") AS \"subseltest\" ON \"subseltest\".\"subsel_id\" = \"ent\".\"subsel_ent_id\""
+   (sql-only
+    (select ent
+     (with subsel)))))
+
 (deftest multiple-aliases
   (defentity blahblah
     (table :blah :bb))


### PR DESCRIPTION
This will help so that when a belongs-to relationship is defined to a parent entity with a subselect table, the fk-key is properly generated using the specified fk option instead of the default-fk-name; issue #300.