### PR TITLE
Applies consistent auto-indent

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -281,9 +281,9 @@
 
   (order query :created :asc)"
   ([query field dir]
-    (update-in query [:order] conj [field (or dir :ASC)]))
+   (update-in query [:order] conj [field (or dir :ASC)]))
   ([query field]
-    (order query field :ASC)))
+   (order query field :ASC)))
 
 (defn values
   "Add records to an insert clause. values can either be a vector of maps or a
@@ -300,13 +300,13 @@
 
 (defn add-joins
   ([query ent rel]
-     (add-joins query ent rel :left))
+   (add-joins query ent rel :left))
   ([query ent rel type]
-     (if-let [join-table (:join-table rel)]
-       (-> query
-           (join* type join-table (sfns/pred-= (:lpk rel) @(:lfk rel)))
-           (join* type ent (sfns/pred-= @(:rfk rel) (:rpk rel))))
-       (join* query type ent (sfns/pred-= (:pk rel) (:fk rel))))))
+   (if-let [join-table (:join-table rel)]
+     (-> query
+         (join* type join-table (sfns/pred-= (:lpk rel) @(:lfk rel)))
+         (join* type ent (sfns/pred-= @(:rfk rel) (:rpk rel))))
+     (join* query type ent (sfns/pred-= (:pk rel) (:fk rel))))))
 
 (defmacro join
   "Add a join clause to a select query, specifying an entity defined by defentity, or the table name to
@@ -320,17 +320,17 @@
   (join query :right addresses (= :address.users_id :users.id))"
   {:arglists '([query ent] [query type ent] [query table clause] [query type table clause])}
   ([query ent]
-     `(join ~query :left ~ent))
+   `(join ~query :left ~ent))
   ([query type-or-table ent-or-clause]
-     `(if (entity? ~ent-or-clause)
-        (let [q# ~query
-              e# ~ent-or-clause
-              rel# (get-rel (:ent q#) e#)
-              type# ~type-or-table]
-          (add-joins q# e# rel# type#))
-        (join ~query :left ~type-or-table ~ent-or-clause)))
+   `(if (entity? ~ent-or-clause)
+      (let [q# ~query
+            e# ~ent-or-clause
+            rel# (get-rel (:ent q#) e#)
+            type# ~type-or-table]
+        (add-joins q# e# rel# type#))
+      (join ~query :left ~type-or-table ~ent-or-clause)))
   ([query type table clause]
-     `(join* ~query ~type ~table (eng/pred-map ~(eng/parse-where clause)))))
+   `(join* ~query ~type ~table (eng/pred-map ~(eng/parse-where clause)))))
 
 (defn post-query
   "Add a function representing a query that should be executed for each result
@@ -482,21 +482,21 @@
         sql (:sql-str query)
         params (:params query)]
     (cond
-     (:sql query) sql
-     (= *exec-mode* :sql) sql
-     (= *exec-mode* :query) query
-     (= *exec-mode* :dry-run) (do
-                                (println "dry run ::" sql "::" (vec params))
-                                (let [result-keys (conj (->> query :ent :rel vals
-                                                             (map deref)
-                                                             (filter (comp #{:belongs-to} :rel-type))
-                                                             (map :fk-key))
-                                                        (-> query :ent :pk))
-                                      results (apply-posts query [(zipmap result-keys (repeat 1))])]
-                                  (first results)
-                                  results))
-     :else (let [results (db/do-query query)]
-             (apply-transforms query (apply-posts query results))))))
+      (:sql query) sql
+      (= *exec-mode* :sql) sql
+      (= *exec-mode* :query) query
+      (= *exec-mode* :dry-run) (do
+                                 (println "dry run ::" sql "::" (vec params))
+                                 (let [result-keys (conj (->> query :ent :rel vals
+                                                              (map deref)
+                                                              (filter (comp #{:belongs-to} :rel-type))
+                                                              (map :fk-key))
+                                                         (-> query :ent :pk))
+                                       results (apply-posts query [(zipmap result-keys (repeat 1))])]
+                                   (first results)
+                                   results))
+      :else (let [results (db/do-query query)]
+              (apply-transforms query (apply-posts query results))))))
 
 (defn exec-raw
   "Execute a raw SQL string, supplying whether results should be returned. `sql`
@@ -537,9 +537,9 @@
 
 (defn- default-fk-name [ent]
   (cond
-   (map? ent) (keyword (str (simple-table-name ent) "_id"))
-   (var? ent) (recur @ent)
-   :else      (throw (Exception. (str "Can't determine default fk for " ent)))))
+    (map? ent) (keyword (str (simple-table-name ent) "_id"))
+    (var? ent) (recur @ent)
+    :else      (throw (Exception. (str "Can't determine default fk for " ent)))))
 
 (defn- many-to-many-keys [parent child {:keys [join-table lfk rfk]}]
   {:lpk (raw (eng/prefix parent (:pk parent)))
@@ -617,9 +617,9 @@
 
 (defn many-to-many-fn [ent sub-ent-var join-table opts]
   (let [opts (assoc opts
-               :join-table join-table
-               :lfk (delay (get opts :lfk (default-fk-name ent)))
-               :rfk (delay (get opts :rfk (default-fk-name sub-ent-var))))]
+                    :join-table join-table
+                    :lfk (delay (get opts :lfk (default-fk-name ent)))
+                    :rfk (delay (get opts :rfk (default-fk-name sub-ent-var))))]
     (rel ent sub-ent-var :many-to-many opts)))
 
 (defmacro many-to-many
@@ -748,20 +748,20 @@
                            (merge-with-unique-keys (get-key-naming-strategy query)
                                                    ent
                                                    (first
-                                                     (select sub-ent
-                                                             (body-fn)
-                                                             (where {sub-ent-key (get ent ent-key)})))))))))
+                                                    (select sub-ent
+                                                            (body-fn)
+                                                            (where {sub-ent-key (get ent ent-key)})))))))))
 
 (defn- with-one-to-one-now [rel query sub-ent body-fn]
   (let [table (if (:alias rel) [(:table sub-ent) (:alias sub-ent)] (:table sub-ent))
         [ent-key sub-ent-key] (get-join-keys rel (:ent query) sub-ent)]
     (bind-query query
                 (merge-query
-                  (make-sub-query sub-ent body-fn)
-                  (join query
-                        table
-                        (= (raw (eng/prefix sub-ent sub-ent-key))
-                           (raw (eng/prefix (:ent query) ent-key))))))))
+                 (make-sub-query sub-ent body-fn)
+                 (join query
+                       table
+                       (= (raw (eng/prefix sub-ent sub-ent-key))
+                          (raw (eng/prefix (:ent query) ent-key))))))))
 
 (defn- with-many-to-many [{:keys [lfk rfk rpk join-table]} query ent body-fn]
   (let [pk (get-in query [:ent :pk])
@@ -780,11 +780,11 @@
     (cond
       (and (#{:belongs-to :has-one} rel-type)
            (not transforms))     (with-one-to-one-now rel query sub-ent body-fn)
-      (#{:belongs-to :has-one} rel-type) (with-one-to-one-later rel query sub-ent body-fn)
-      (= :has-many rel-type)     (with-one-to-many rel query sub-ent body-fn)
-      (= :many-to-many rel-type) (with-many-to-many rel query sub-ent body-fn)
-      :else (throw (Exception. (str "No relationship defined for table: "
-                                    (:table sub-ent)))))))
+           (#{:belongs-to :has-one} rel-type) (with-one-to-one-later rel query sub-ent body-fn)
+           (= :has-many rel-type)     (with-one-to-many rel query sub-ent body-fn)
+           (= :many-to-many rel-type) (with-many-to-many rel query sub-ent body-fn)
+           :else (throw (Exception. (str "No relationship defined for table: "
+                                         (:table sub-ent)))))))
 
 (defmacro with
   "Add a related entity to the given select query. If the entity has a relationship
@@ -844,7 +844,7 @@
                                            (ensure-valid-subquery))
                         child-rows-by-pk (group-by fk-key child-rows)]
                     (map #(assoc %
-                            table (get child-rows-by-pk (get % pk)))
+                                 table (get child-rows-by-pk (get % pk)))
                          rows))))))
 
 (defn with-batch* [query sub-ent body-fn]

--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -253,7 +253,7 @@
   []
   (jdbc/db-is-rollback-only *current-conn*))
 
-(defn- exec-sql [{:keys [results sql-str params options]}]  
+(defn- exec-sql [{:keys [results sql-str params options]}]
   (let [{:keys [keys]} (:naming (or options @conf/options))]
     (case results
       :results (jdbc/query *current-conn*

--- a/src/korma/mysql.clj
+++ b/src/korma/mysql.clj
@@ -3,10 +3,9 @@
   (:use [korma.sql.engine :only [sql-func]])
   (:refer-clojure :exclude [count]))
 
-
 (defn count
   "On MySQL, when an argument for COUNT() is a '*',
-   it must be a simple '*', instead of 'fieldname.*'."
+  it must be a simple '*', instead of 'fieldname.*'."
   [_query_ v]
   (if (= "*" (name v))
     (sql-func "COUNT" (utils/generated "*"))

--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -47,14 +47,14 @@
         sub (utils/sub-query? v)
         pred (utils/pred? v)]
     (cond
-     generated generated
-     pred (apply pred args)
-     func (let [vs (comma-values args)]
-            (format func vs))
-     sub (do
-           (swap! *bound-params* utils/vconcat (:params sub))
-           (utils/wrap (:sql-str sub)))
-     :else (pred-map v))))
+      generated generated
+      pred (apply pred args)
+      func (let [vs (comma-values args)]
+             (format func vs))
+      sub (do
+            (swap! *bound-params* utils/vconcat (:params sub))
+            (utils/wrap (:sql-str sub)))
+      :else (pred-map v))))
 
 (defn table-alias [{:keys [table alias]}]
   (or alias table))
@@ -67,14 +67,14 @@
 
 (defn field-identifier [field]
   (cond
-   (map? field) (map-val field)
-   (string? field) field
-   (= "*" (name field)) "*"
-   :else (let [field-name (name field)
-               parts (string/split field-name #"\.")]
-           (if-not (next parts)
-             (delimit-str field-name)
-             (string/join "." (map delimit-str parts))))))
+    (map? field) (map-val field)
+    (string? field) field
+    (= "*" (name field)) "*"
+    :else (let [field-name (name field)
+                parts (string/split field-name #"\.")]
+            (if-not (next parts)
+              (delimit-str field-name)
+              (string/join "." (map delimit-str parts))))))
 
 (defn prefix [ent field]
   (let [field-name (field-identifier field)
@@ -104,9 +104,9 @@
                         v
                         [v nil])
         fname (cond
-               (map? fname) (map-val fname)
-               *bound-table* (prefix *bound-table* fname)
-               :else (field-identifier fname))
+                (map? fname) (map-val fname)
+                *bound-table* (prefix *bound-table* fname)
+                :else (field-identifier fname))
         alias-str (alias-clause alias)]
     (str fname alias-str)))
 
@@ -117,9 +117,9 @@
   (if (utils/special-map? v)
     (map-val v)
     (let [tstr (cond
-                (string? v) v
-                (map? v) (:table v)
-                :else (name v))]
+                 (string? v) v
+                 (map? v) (:table v)
+                 :else (name v))]
       (table-identifier tstr))))
 
 (defn parameterize [v]
@@ -199,9 +199,9 @@
 
 (defn pred-= [k v]
   (cond
-   (not-nil? k v) (infix k "=" v)
-   (not-nil? k) (infix k "IS" v)
-   (not-nil? v) (infix v "IS" k)))
+    (not-nil? k v) (infix k "=" v)
+    (not-nil? k) (infix k "IS" v)
+    (not-nil? v) (infix v "IS" k)))
 
 (defn set= [[k v]]
   (map-val (infix k "=" v)))
@@ -254,14 +254,14 @@
 
 (defn from-table [v & [already-aliased?]]
   (cond
-   (string? v) (table-str v)
-   (vector? v) (let [[table alias] v]
-                 (str (from-table table :aliased) (alias-clause alias)))
-   (map? v) (if (:table v)
-              (let [{:keys [table alias]} v]
-                (str (table-str table) (when-not already-aliased? (alias-clause alias))))
-              (map-val v))
-   :else (table-str v)))
+    (string? v) (table-str v)
+    (vector? v) (let [[table alias] v]
+                  (str (from-table table :aliased) (alias-clause alias)))
+    (map? v) (if (:table v)
+               (let [{:keys [table alias]} v]
+                 (str (table-str table) (when-not already-aliased? (alias-clause alias))))
+               (map-val v))
+    :else (table-str v)))
 
 (defn join-clause [join-type table on-clause]
   (let [join-type (string/upper-case (name join-type))

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -30,9 +30,9 @@
 
 (def pred-= eng/pred-=)
 (defn pred-not= [k v] (cond
-                       (and k v) (infix k "<>" v)
-                       k         (infix k "IS NOT" v)
-                       v         (infix v "IS NOT" k)))
+                        (and k v) (infix k "<>" v)
+                        k         (infix k "IS NOT" v)
+                        v         (infix v "IS NOT" k)))
 
 ;;*****************************************************
 ;; Aggregates

--- a/src/korma/sql/utils.clj
+++ b/src/korma/sql/utils.clj
@@ -49,9 +49,9 @@
 (defn left-assoc [vs]
   (loop [ret "" [v & vs] vs]
     (cond
-     (nil? v) ret
-     (nil? vs) (str ret v)
-     :else (recur (wrap (str ret v)) vs))))
+      (nil? v) ret
+      (nil? vs) (str ret v)
+      :else (recur (wrap (str ret v)) vs))))
 
 ;;*****************************************************
 ;; collection-utils

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -67,32 +67,32 @@
 
 (deftest simple-selects
   (sql-only
-    (are [query result] (= query result)
-         (select users)
-         "SELECT \"users\".* FROM \"users\""
-         (select users-alias)
-         "SELECT \"u\".* FROM \"users\" AS \"u\""
-         (select users-with-entity-fields)
-         "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
-         (select users-with-friend (with f/friend))
-         "SELECT \"users\".*, \"friend\".* FROM \"users\" LEFT JOIN \"friend\" ON \"friend\".\"users_id\" = \"users\".\"id\""
-         (select users
-                 (fields :id :username))
-         "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
-         (select users
-                 (where {:username "chris"
-                         :email "hey@hey.com"}))
-         "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"email\" = ? AND \"users\".\"username\" = ?)"
-         (select users
-                 (where {:username "chris"})
-                 (order :created))
-         "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"username\" = ?) ORDER BY \"users\".\"created\" ASC"
-         (select users
-                 (where {:active true})
-                 (order :created)
-                 (limit 5)
-                 (offset 3))
-         "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"active\" = ?) ORDER BY \"users\".\"created\" ASC LIMIT 5 OFFSET 3")))
+   (are [query result] (= query result)
+        (select users)
+        "SELECT \"users\".* FROM \"users\""
+        (select users-alias)
+        "SELECT \"u\".* FROM \"users\" AS \"u\""
+        (select users-with-entity-fields)
+        "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
+        (select users-with-friend (with f/friend))
+        "SELECT \"users\".*, \"friend\".* FROM \"users\" LEFT JOIN \"friend\" ON \"friend\".\"users_id\" = \"users\".\"id\""
+        (select users
+                (fields :id :username))
+        "SELECT \"users\".\"id\", \"users\".\"username\" FROM \"users\""
+        (select users
+                (where {:username "chris"
+                        :email "hey@hey.com"}))
+        "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"email\" = ? AND \"users\".\"username\" = ?)"
+        (select users
+                (where {:username "chris"})
+                (order :created))
+        "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"username\" = ?) ORDER BY \"users\".\"created\" ASC"
+        (select users
+                (where {:active true})
+                (order :created)
+                (limit 5)
+                (offset 3))
+        "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"active\" = ?) ORDER BY \"users\".\"created\" ASC LIMIT 5 OFFSET 3")))
 
 (deftest update-function
   (is (= "UPDATE \"users\" SET \"first\" = ?, \"last\" = ? WHERE (\"users\".\"id\" = ?)"
@@ -147,20 +147,20 @@
 
 (deftest insert-queries
   (sql-only
-    (are [result query] (= result query)
-         "INSERT INTO \"users\" (\"first\", \"last\") VALUES (?, ?)"
-         (insert users
-                 (values {:first "chris" :last "granger"}))
-         "INSERT INTO \"users\" (\"first\", \"last\") VALUES (?, ?), (?, ?)"
-         (insert users
-                 (values [{:first "chris" :last "granger"}
-                          {:last "jordan" :first "michael"}]))
-         "DO 0"
-         (insert users (values {}))
-         "DO 0"
-         (insert users (values []))
-         "DO 0"
-         (insert users (values [{} {}])))))
+   (are [result query] (= result query)
+        "INSERT INTO \"users\" (\"first\", \"last\") VALUES (?, ?)"
+        (insert users
+                (values {:first "chris" :last "granger"}))
+        "INSERT INTO \"users\" (\"first\", \"last\") VALUES (?, ?), (?, ?)"
+        (insert users
+                (values [{:first "chris" :last "granger"}
+                         {:last "jordan" :first "michael"}]))
+        "DO 0"
+        (insert users (values {}))
+        "DO 0"
+        (insert users (values []))
+        "DO 0"
+        (insert users (values [{} {}])))))
 
 (deftest complex-where
   (sql-only
@@ -201,9 +201,9 @@
 (deftest with-many
   (with-out-str
     (dry-run
-      (is (= [{:id 1 :email [{:id 1}]}]
-             (select user2
-                     (with email)))))))
+     (is (= [{:id 1 :email [{:id 1}]}]
+            (select user2
+                    (with email)))))))
 
 (deftest with-many-batch
   (is (= "dry run :: SELECT \"users\".* FROM \"users\" :: []\ndry run :: SELECT \"email\".* FROM \"email\" WHERE (\"email\".\"users_id\" IN (?)) :: [1]\n"
@@ -335,8 +335,8 @@
   (let [delimiters (:delimiters @options)]
     (set-delimiters "`")
     (sql-only
-      (is (= "SELECT `users`.* FROM `users`"
-             (select user2))))
+     (is (= "SELECT `users`.* FROM `users`"
+            (select user2))))
     (apply set-delimiters delimiters)))
 
 (deftest naming-delim-options
@@ -358,25 +358,25 @@
 
 (deftest false-set-in-update
   (query-only
-    (are [result query] (= result (select-keys query [:sql-str :params]))
-         {:sql-str "UPDATE \"users\" SET \"blah\" = ?" :params [false]}
-         (update user2 (set-fields {:blah false}))
+   (are [result query] (= result (select-keys query [:sql-str :params]))
+        {:sql-str "UPDATE \"users\" SET \"blah\" = ?" :params [false]}
+        (update user2 (set-fields {:blah false}))
 
-         {:sql-str "UPDATE \"users\" SET \"blah\" = NULL" :params []}
-         (update user2 (set-fields {:blah nil}))
+        {:sql-str "UPDATE \"users\" SET \"blah\" = NULL" :params []}
+        (update user2 (set-fields {:blah nil}))
 
-         {:sql-str "UPDATE \"users\" SET \"blah\" = ?" :params [true]}
-         (update user2 (set-fields {:blah true})))))
+        {:sql-str "UPDATE \"users\" SET \"blah\" = ?" :params [true]}
+        (update user2 (set-fields {:blah true})))))
 
 (deftest raws
   (sql-only
-    (are [result query] (= result query)
-         "SELECT \"users\".* FROM \"users\" WHERE (ROWNUM >= ?)"
-         (select user2 (where {(raw "ROWNUM") [>= 5]}))
+   (are [result query] (= result query)
+        "SELECT \"users\".* FROM \"users\" WHERE (ROWNUM >= ?)"
+        (select user2 (where {(raw "ROWNUM") [>= 5]}))
 
-         "SELECT \"users\".* FROM \"users\" WHERE (MONTH(create_date) = ? AND YEAR(create_date) = ?)"
-         (select user2 (where {(raw "YEAR(create_date)")  2013
-                               (raw "MONTH(create_date)") 12})))))
+        "SELECT \"users\".* FROM \"users\" WHERE (MONTH(create_date) = ? AND YEAR(create_date) = ?)"
+        (select user2 (where {(raw "YEAR(create_date)")  2013
+                              (raw "MONTH(create_date)") 12})))))
 
 (deftest pk-dry-run
   (let [result (with-out-str
@@ -396,24 +396,24 @@
 
        "SELECT \"state\".* FROM \"state\" WHERE EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND \"address\".\"state_id\" = \"state\".\"id\")))"
        (sql-only
-         (select state
-                 (where (exists (subselect address 
-                                           (where (and {:id [> 5]} (= :state_id :state.id))))))))
+        (select state
+                (where (exists (subselect address
+                                          (where (and {:id [> 5]} (= :state_id :state.id))))))))
 
        "SELECT \"state\".* FROM \"state\" WHERE (EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND \"address\".\"state_id\" = \"state\".\"id\"))) AND NOT(EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" < ?) OR \"address\".\"state_id\" <> \"state\".\"id\")))))"
        (sql-only
-         (select state
-                 (where (and (exists (subselect address 
-                                           (where (and {:id [> 5]} (= :state_id :state.id)))))
-                             (not (exists (subselect address
-                                           (where (or  {:id [< 10]} (not= :state_id :state.id))))))))))
+        (select state
+                (where (and (exists (subselect address
+                                               (where (and {:id [> 5]} (= :state_id :state.id)))))
+                            (not (exists (subselect address
+                                                    (where (or  {:id [< 10]} (not= :state_id :state.id))))))))))
 
        "SELECT \"state\".* FROM \"state\" WHERE EXISTS((SELECT \"address\".* FROM \"address\" WHERE ((\"address\".\"id\" > ?) AND NOT(EXISTS((SELECT \"users\".* FROM \"users\" WHERE \"address\".\"user_id\" = \"users\".\"id\"))))))"
        (sql-only
-         (select state
-                 (where (exists (subselect address 
-                                           (where (and {:id [> 5]} 
-                                                       (not (exists (subselect user2 (where (= :address.user_id :id))))))))))))
+        (select state
+                (where (exists (subselect address
+                                          (where (and {:id [> 5]}
+                                                      (not (exists (subselect user2 (where (= :address.user_id :id))))))))))))
 
        "SELECT \"users\".* FROM \"users\", (SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"age\" > ?)) AS \"u2\""
        (sql-only
@@ -485,18 +485,18 @@
         (select subsel))))
 
 (deftest entity-with-belongs-to-subselect
- (defentity subsel
-  (pk :subsel_id)
-  (table  (subselect "test") :subseltest))
+  (defentity subsel
+    (pk :subsel_id)
+    (table  (subselect "test") :subseltest))
   (defentity ent
-   (table :ent)
-   (pk :ent_id)
-   (belongs-to subsel  {:fk :subsel_ent_id}))
+    (table :ent)
+    (pk :ent_id)
+    (belongs-to subsel  {:fk :subsel_ent_id}))
   (are  [result query]  (= result query)
-   "SELECT \"ent\".*, \"subseltest\".* FROM \"ent\" LEFT JOIN (SELECT \"test\".* FROM \"test\") AS \"subseltest\" ON \"subseltest\".\"subsel_id\" = \"ent\".\"subsel_ent_id\""
-   (sql-only
-    (select ent
-     (with subsel)))))
+        "SELECT \"ent\".*, \"subseltest\".* FROM \"ent\" LEFT JOIN (SELECT \"test\".* FROM \"test\") AS \"subseltest\" ON \"subseltest\".\"subsel_id\" = \"ent\".\"subsel_ent_id\""
+        (sql-only
+         (select ent
+                 (with subsel)))))
 
 (deftest multiple-aliases
   (defentity blahblah

--- a/test/korma/test/integration/helpers.clj
+++ b/test/korma/test/integration/helpers.clj
@@ -63,28 +63,28 @@
   "add up to max-addresses-per-user addresses to each user. ensure that at least one user has no addresses at all"
   [data max-addresses-per-user]
   (assoc data
-    :user (vec
-           (cons
-            (first (:user data))
-            (map
-             (fn [user]
-               (let [addrs (doall
-                            (for [n (range (rand-int max-addresses-per-user))]
-                              (let [a {:user_id (:id user)
-                                       :street (random-string)
-                                       :number (subs (random-string) 0 10)
-                                       :city (random-string)
-                                       :zip (str (rand-int 10000))
-                                       :state_id (-> data :state rand-nth :id)}
-                                    inserted (insert address (values a))
-                                    ;; insert returns a map with a single key
-                                    ;; the key depends on the underlying database, but the
-                                    ;; value is the generated value of the key column
-                                    inserted-id (first (vals inserted))
-                                    a (assoc a :id inserted-id)]
-                                a)))]
-                 (assoc user :address (vec addrs))))
-             (rest (:user data)))))))
+         :user (vec
+                (cons
+                 (first (:user data))
+                 (map
+                  (fn [user]
+                    (let [addrs (doall
+                                 (for [n (range (rand-int max-addresses-per-user))]
+                                   (let [a {:user_id (:id user)
+                                            :street (random-string)
+                                            :number (subs (random-string) 0 10)
+                                            :city (random-string)
+                                            :zip (str (rand-int 10000))
+                                            :state_id (-> data :state rand-nth :id)}
+                                         inserted (insert address (values a))
+                                         ;; insert returns a map with a single key
+                                         ;; the key depends on the underlying database, but the
+                                         ;; value is the generated value of the key column
+                                         inserted-id (first (vals inserted))
+                                         a (assoc a :id inserted-id)]
+                                     a)))]
+                      (assoc user :address (vec addrs))))
+                  (rest (:user data)))))))
 
 (defn populate
   "populate the test database with random data and return a data structure that mirrors the data inserted into the database."

--- a/test/korma/test/integration/per_query_database.clj
+++ b/test/korma/test/integration/per_query_database.clj
@@ -34,5 +34,5 @@
 (deftest use-database-from-parent-when-fetching-children
   (is (= [{:id 1 :name "Chris" :email [{:id 1 :user_id 1 :email_address "chris@email.com"}]}]
          (select user
-           (database mem-db)
-           (with email)))))
+                 (database mem-db)
+                 (with email)))))

--- a/test/korma/test/integration/with_db.clj
+++ b/test/korma/test/integration/with_db.clj
@@ -37,13 +37,13 @@
       ;; using a CountDownLatch to synchronize their execution
       (let [latch (CountDownLatch. 2)
             t1 (future (with-db db2
-                      (.countDown latch)
-                      (.await latch)
-                      (delete-some-rows-from-db)))
+                         (.countDown latch)
+                         (.await latch)
+                         (delete-some-rows-from-db)))
             t2 (future (with-db db1
-                      (.countDown latch)
-                      (.await latch)
-                      (delete-some-rows-from-db)))]
+                         (.countDown latch)
+                         (.await latch)
+                         (delete-some-rows-from-db)))]
         @t1
         @t2
         (.await latch))

--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -45,8 +45,8 @@
 
 (defn- setup-korma-db []
   (jdbc/db-do-commands mysql-uri "CREATE DATABASE IF NOT EXISTS korma;"
-                                 "USE korma;"
-                                 "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200));"))
+                       "USE korma;"
+                       "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200));"))
 
 (defn- clean-korma-db []
   (jdbc/db-do-commands mysql-uri "DROP DATABASE korma;"))


### PR DESCRIPTION
I mentioned earlier that whitespace is not always consistent in Korma (sometimes even within file). Mostly becomes a pain when making a small PR which ends up 90% whitespace changes.
I basically did a dummy update on all files with Emacs, using auto-indent defaults so things would end up the same across the code (and tests).