### PR TITLE
removed options from query/ent where it's no longer needed; issue #312

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -20,13 +20,12 @@
   (let [ent (if (keyword? ent)
               (name ent)
               ent)
-        [ent table alias db opts] (if (string? ent)
-                                    [{:table ent} ent nil nil nil]
-                                    [ent (:table ent) (:alias ent) (:db ent) (get-in ent [:db :options])])]
+        [ent table alias db] (if (string? ent)
+                               [{:table ent} ent nil nil]
+                               [ent (:table ent) (:alias ent) (:db ent)])]
     {:ent ent
      :table table
      :db db
-     :options opts
      :alias alias}))
 
 (defmacro ^{:private true} make-query [ent m]
@@ -713,7 +712,7 @@
 (defn database
   "Set the database connection to be used for this entity."
   [ent db]
-  (assoc ent :db db :options (:options db)))
+  (assoc ent :db db ))
 
 (defn transform
   "Add a function to be applied to results coming from the database"

--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -147,7 +147,9 @@
                              (table-alias ~query)
                              (:table ~query))
              *bound-aliases* (or (:aliases ~query) #{})
-             *bound-options* (or (:options ~query) (:options db/*current-db*) (:options @db/_default))]
+             *bound-options* (or (get-in ~query [:db :options])
+                                 (:options db/*current-db*)
+                                 (:options @db/_default))]
      ~@body))
 
 ;;*****************************************************


### PR DESCRIPTION
I removed the options from the query, and also from the ent; neither was needed anymore since the ent options were only being used to assoc into the query.