### PR TITLE
Generate a connection spec from a database URI (jdbc as well as native formats) for the databases that are client server (not h2, not sqlite).

### DIFF
--- a/test/korma/test/mysql.clj
+++ b/test/korma/test/mysql.clj
@@ -12,6 +12,24 @@
 (defentity users-mysql (database test-db-mysql))
 (defentity users-non-mysql (database test-db-non-mysql))
 
+(deftest connection-spec-by-uri
+  (is (= (postgres {:db "db_name" :user "user_name" :password "password"})
+         (db-uri "jdbc:postgresql://localhost/db_name?user=user_name&password=password")))
+  (is (= (postgres {:db "db_name" :user "user_name" :password "password"})
+         (db-uri "postgres://user_name:password@localhost/db_name")))
+  (is (= (postgres {:db "db_name" :user "user_name" :password "password", :host "hostname", :port 5000})
+         (db-uri "jdbc:postgresql://hostname:5000/db_name?user=user_name&password=password")))
+  (is (= (postgres {:db "db_name" :user "user_name" :password "password", :host "hostname", :port 5000})
+         (db-uri "postgres://user_name:password@hostname:5000/db_name")))
+  (is (= (mysql {:db "db_name" :user "user_name" :password "password"})
+         (db-uri "jdbc:mysql://localhost/db_name?user=user_name&password=password")))
+  (is (= (mysql {:db "db_name" :user "user_name" :password "password"})
+         (db-uri "mysql://user_name:password@localhost/db_name")))
+  (is (= (mysql {:db "db_name" :user "user_name" :password "password", :host "hostname", :port 5000})
+         (db-uri "jdbc:mysql://hostname:5000/db_name?user=user_name&password=password")))
+  (is (= (mysql {:db "db_name" :user "user_name" :password "password", :host "hostname", :port 5000})
+         (db-uri "mysql://user_name:password@hostname:5000/db_name"))))
+
 (deftest test-mysql-count
   (sql-only
    (are [result query] (= result query)


### PR DESCRIPTION
We were recently integrating Korma into Luminus and the fact that Korma could not just accept database URIs to connect was problematic, so here I have an initial implementation of it. It can parse both jdbc as well as the native URLs some databases uses, like the one Heroku gives you for PostgreSQL.

I played a bit trying to find the best way to implement this because I'm deconstructing the uri only for your code to reconstruct it later, which seems like a waste. But in the middle you add some sane defaults, like back-ticks for quoting MySQL identifies. I don't think I could have added a way to not deconstruct-reconstruct the URI without a lot of modification to the current code, which was not my goal.

When searching for a solution to this problem I actually found lot's of people running into this problem with either no solutions or hacky ones, which prompted me to put the time to do what I see as a proper fix. What do you think? Is this something you might want to merge? Let me know if you require changes for it.