### PR TITLE
Functions that generate database specifications generate connection-uri.

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -24,11 +24,11 @@
 (defn extract-options [{:keys [naming
                                delimiters 
                                alias-delimiter
-                               subprotocol]}]
+                               connection-uri]}]
   {:naming (->naming naming)
    :delimiters (->delimiters delimiters)
    :alias-delimiter (->alias-delimiter alias-delimiter)
-   :subprotocol subprotocol})
+   :connection-uri connection-uri})
 
 (defn default-connection
   "Set the database connection that Korma should use by default when no
@@ -54,7 +54,7 @@
 
 (defn connection-pool
   "Create a connection pool for the given database spec."
-  [{:keys [subprotocol subname classname
+  [{:keys [connection-uri classname
            excess-timeout idle-timeout
            initial-pool-size minimum-pool-size maximum-pool-size
            test-connection-query
@@ -75,9 +75,9 @@
     (throw (Exception. "com.mchange.v2.c3p0.ComboPooledDataSource not found in class path."))) 
   {:datasource (doto (resolve-new ComboPooledDataSource)
                  (.setDriverClass classname)
-                 (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
+                 (.setJdbcUrl connection-uri)
                  (.setProperties (as-properties (dissoc spec
-                                                        :make-pool? :classname :subprotocol :subname
+                                                        :make-pool? :classname :connection-uri
                                                         :naming :delimiters :alias-delimiter
                                                         :excess-timeout :idle-timeout
                                                         :initial-pool-size :minimum-pool-size :maximum-pool-size
@@ -139,8 +139,7 @@
     :or {host "localhost", port 3050, db "", make-pool? true}
     :as opts}]
   (merge {:classname "org.firebirdsql.jdbc.FBDriver" ; must be in classpath
-          :subprotocol "firebirdsql"
-          :subname (str host "/" port ":" db)
+          :connection-uri (str "jdbc:firebirdsql:" host "/" port ":" db)
           :make-pool? make-pool?
           :encoding "UTF8"}
          (dissoc opts :host :port :db)))
@@ -153,8 +152,7 @@
     :or {host "localhost", port 5432, db "", make-pool? true}
     :as opts}]
   (merge {:classname "org.postgresql.Driver" ; must be in classpath
-          :subprotocol "postgresql"
-          :subname (str "//" host ":" port "/" db)
+          :connection-uri (str "jdbc:postgresql://" host ":" port "/" db)
           :make-pool? make-pool?}
          (dissoc opts :host :port :db)))
 
@@ -165,8 +163,7 @@
     :or {host "localhost", port 1521, make-pool? true}
     :as opts}]
   (merge {:classname "oracle.jdbc.driver.OracleDriver" ; must be in classpath
-          :subprotocol "oracle:thin"
-          :subname (str "@" host ":" port)
+          :connection-uri (str "jdbc:oracle:thin:@" host ":" port)
           :make-pool? make-pool?}
          (dissoc opts :host :port)))
 
@@ -178,8 +175,7 @@
     :or {host "localhost", port 3306, db "", make-pool? true}
     :as opts}]
   (merge {:classname "com.mysql.jdbc.Driver" ; must be in classpath
-          :subprotocol "mysql"
-          :subname (str "//" host ":" port "/" db)
+          :connection-uri (str "jdbc:mysql://" host ":" port "/" db)
           :delimiters "`"
           :make-pool? make-pool?}
          (dissoc opts :host :port :db)))
@@ -192,8 +188,7 @@
     :or {host "localhost", port 5433, db "", make-pool? true}
     :as opts}]
   (merge {:classname "com.vertica.jdbc.Driver" ; must be in classpath
-          :subprotocol "vertica"
-          :subname (str "//" host ":" port "/" db)
+          :connection-uri (str "jdbc:vertica://" host ":" port "/" db)
           :delimiters "\""
           :make-pool? make-pool?}
          (dissoc opts :host :port :db)))
@@ -206,8 +201,7 @@
     :or {user "dbuser", password "dbpassword", db "", host "localhost", port 1433, make-pool? true}
     :as opts}]
   (merge {:classname "com.microsoft.sqlserver.jdbc.SQLServerDriver" ; must be in classpath
-          :subprotocol "sqlserver"
-          :subname (str "//" host ":" port ";database=" db ";user=" user ";password=" password)
+          :connection-uri (str "jdbc:sqlserver://" host ":" port ";database=" db ";user=" user ";password=" password)
           :make-pool? make-pool?}
          (dissoc opts :host :port :db)))
 
@@ -218,10 +212,9 @@
     :or {db "", make-pool? false}
     :as opts}]
   (merge {:classname "sun.jdbc.odbc.JdbcOdbcDriver" ; must be in classpath
-          :subprotocol "odbc"
-          :subname (str "Driver={Microsoft Access Driver (*.mdb"
-                        (when (.endsWith db ".accdb") ", *.accdb")
-                        ")};Dbq=" db)
+          :connection-uri (str "jdbc:odbc:" (str "Driver={Microsoft Access Driver (*.mdb"
+                                      (when (.endsWith db ".accdb") ", *.accdb")
+                                      ")};Dbq=" db))
           :make-pool? make-pool?}
          (dissoc opts :db)))
 
@@ -232,8 +225,7 @@
     :or {dsn "", make-pool? true}
     :as opts}]
   (merge {:classname "sun.jdbc.odbc.JdbcOdbcDriver" ; must be in classpath
-          :subprotocol "odbc"
-          :subname dsn
+          :connection-uri (str "jdbc:odbc:" dsn)
           :make-pool? make-pool?}
          (dissoc opts :dsn)))
 
@@ -244,8 +236,7 @@
     :or {db "sqlite.db", make-pool? true}
     :as opts}]
   (merge {:classname "org.sqlite.JDBC" ; must be in classpath
-          :subprotocol "sqlite"
-          :subname db
+          :connection-uri (str "jdbc:sqlite:" db)
           :make-pool? make-pool?}
          (dissoc opts :db)))
 
@@ -256,8 +247,7 @@
     :or {db "h2.db", make-pool? true}
     :as opts}]
   (merge {:classname "org.h2.Driver" ; must be in classpath
-          :subprotocol "h2"
-          :subname db
+          :connection-uri (str "jdbc:h2:" db)
           :make-pool? make-pool?}
          (dissoc opts :db)))
 

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -39,8 +39,10 @@
 ;;*****************************************************
 
 (defn- subprotocol [query]
-  (let [default (get-in @db/_default [:options :subprotocol])]
-    (or (get-in query [:db :options :subprotocol]) default)))
+  (let [default (get-in @db/_default [:options :connection-uri])]
+    (second (clojure.string/split
+              (or (get-in query [:db :options :connection-uri]) default)
+              #":"))))
 
 (defn agg-count [query v]
   (if (= "mysql" (subprotocol query))

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -14,15 +14,13 @@
 
 (def db-config-with-defaults
   {:classname "org.h2.Driver"
-   :subprotocol "h2"
-   :subname "mem:db_connectivity_test_db"
+   :connection-uri "jdbc:h2:mem:db_connectivity_test_db"
    :user "bob"
    :password "password"})
 
 (def db-config-with-options-set
   {:classname "org.h2.Driver"
-   :subprotocol "h2"
-   :subname "mem:db_connectivity_test_db"
+   :connection-uri "jdbc:h2:mem:db_connectivity_test_db"
    :excess-timeout 99
    :idle-timeout 88
    :initial-pool-size 10
@@ -33,10 +31,10 @@
    :useUnicode true
    :connectTimeout 1000})
 
-(deftest can-extract-options-merging-subprotocol
+(deftest can-extract-options-merging-uri
   (let [original (extract-options nil)]
-    (is (= (assoc original :subprotocol "anysql") 
-           (extract-options {:subprotocol "anysql"})))))
+    (is (= (assoc original :connection-uri "anysql")
+           (extract-options {:connection-uri "anysql"})))))
 
 (deftest can-extract-options-merging-delimiters
     (let [original (extract-options nil)]
@@ -94,15 +92,13 @@
 (deftest test-firebird
   (testing "firebirdsql - defaults"
     (is (= {:classname "org.firebirdsql.jdbc.FBDriver"
-            :subprotocol "firebirdsql"
-            :subname "localhost/3050:"
+            :connection-uri "jdbc:firebirdsql:localhost/3050:"
             :make-pool? true
             :encoding "UTF8"}
            (firebird {}))))
   (testing "firebirdsql - options selected"
     (is (= {:classname "org.firebirdsql.jdbc.FBDriver"
-            :subprotocol "firebirdsql"
-            :subname "host/port:db"
+            :connection-uri "jdbc:firebirdsql:host/port:db"
             :make-pool? false
             :encoding "NONE"}
            (firebird {:host "host"
@@ -114,14 +110,12 @@
 (deftest test-postgres
   (testing "postgres - defaults"
     (is (= {:classname "org.postgresql.Driver"
-            :subprotocol "postgresql"
-            :subname "//localhost:5432/"
+            :connection-uri "jdbc:postgresql://localhost:5432/"
             :make-pool? true}
            (postgres {}))))
   (testing "postgres - options selected"
     (is (= {:classname "org.postgresql.Driver"
-            :subprotocol "postgresql"
-            :subname "//host:port/db"
+            :connection-uri "jdbc:postgresql://host:port/db"
             :make-pool? false}
            (postgres {:host "host"
                       :port "port"
@@ -131,14 +125,12 @@
 (deftest test-oracle
   (testing "oracle - defaults"
     (is (= {:classname "oracle.jdbc.driver.OracleDriver"
-            :subprotocol "oracle:thin"
-            :subname "@localhost:1521"
+            :connection-uri "jdbc:oracle:thin:@localhost:1521"
             :make-pool? true}
            (oracle {}))))
   (testing "oracle - options selected"
     (is (= {:classname "oracle.jdbc.driver.OracleDriver"
-            :subprotocol "oracle:thin"
-            :subname "@host:port"
+            :connection-uri "jdbc:oracle:thin:@host:port"
             :make-pool? false}
            (oracle {:host "host"
                     :port "port"
@@ -147,15 +139,13 @@
 (deftest test-mysql
   (testing "mysql - defaults"
     (is (= {:classname "com.mysql.jdbc.Driver"
-            :subprotocol "mysql"
-            :subname "//localhost:3306/"
+            :connection-uri "jdbc:mysql://localhost:3306/"
             :delimiters "`"
             :make-pool? true}
            (mysql {}))))
   (testing "mysql - options selected"
     (is (= {:classname "com.mysql.jdbc.Driver"
-            :subprotocol "mysql"
-            :subname "//host:port/db"
+            :connection-uri "jdbc:mysql://host:port/db"
             :delimiters "`"
             :make-pool? false}
            (mysql {:host "host"
@@ -166,15 +156,13 @@
 (deftest test-vertica
   (testing "vertica - defaults"
     (is (= {:classname "com.vertica.jdbc.Driver"
-            :subprotocol "vertica"
-            :subname "//localhost:5433/"
+            :connection-uri "jdbc:vertica://localhost:5433/"
             :delimiters "\""
             :make-pool? true}
            (vertica {}))))
   (testing "vertica - options selected"
     (is (= {:classname "com.vertica.jdbc.Driver"
-            :subprotocol "vertica"
-            :subname "//host:port/db"
+            :connection-uri "jdbc:vertica://host:port/db"
             :delimiters "\""
             :make-pool? false}
            (vertica {:host "host"
@@ -185,16 +173,14 @@
 (deftest test-mssql
   (testing "mssql - defaults"
     (is (= {:classname "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-            :subprotocol "sqlserver"
-            :subname "//localhost:1433;database=;user=dbuser;password=dbpassword"
+            :connection-uri "jdbc:sqlserver://localhost:1433;database=;user=dbuser;password=dbpassword"
             :make-pool? true}
            (mssql {}))))
   (testing "mssql - options selected"
     (is (= {:password "password"
             :user "user"
             :classname "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-            :subprotocol "sqlserver"
-            :subname "//host:port;database=db;user=user;password=password"
+            :connection-uri "jdbc:sqlserver://host:port;database=db;user=user;password=password"
             :make-pool? false}
            (mssql {:host "host"
                    :port "port"
@@ -206,20 +192,17 @@
 (deftest test-msaccess
   (testing "msaccess - defaults"
     (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
-            :subprotocol "odbc"
-            :subname "Driver={Microsoft Access Driver (*.mdb)};Dbq="
+            :connection-uri "jdbc:odbc:Driver={Microsoft Access Driver (*.mdb)};Dbq="
             :make-pool? false}
            (msaccess {}))))
   (testing "msaccess - .mdb selected"
     (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
-            :subprotocol "odbc"
-            :subname "Driver={Microsoft Access Driver (*.mdb)};Dbq=db.mdb"
+            :connection-uri "jdbc:odbc:Driver={Microsoft Access Driver (*.mdb)};Dbq=db.mdb"
             :make-pool? true}
            (msaccess {:db "db.mdb" :make-pool? true}))))
   (testing "msaccess - .accdb selected"
     (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
-            :subprotocol "odbc"
-            :subname (str "Driver={Microsoft Access Driver (*.mdb, *.accdb)};"
+            :connection-uri (str "jdbc:odbc:Driver={Microsoft Access Driver (*.mdb, *.accdb)};"
                           "Dbq=db.accdb")
             :make-pool? true}
            (msaccess {:db "db.accdb" :make-pool? true})))))
@@ -227,42 +210,36 @@
 (deftest test-odbc
   (testing "odbc - defaults"
     (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
-            :subprotocol "odbc"
-            :subname ""
+            :connection-uri "jdbc:odbc:"
             :make-pool? true}
            (odbc {}))))
   (testing "odbc - options selected"
     (is (= {:classname "sun.jdbc.odbc.JdbcOdbcDriver"
-            :subprotocol "odbc"
-            :subname "MyDsn"
+            :connection-uri "jdbc:odbc:MyDsn"
             :make-pool? false}
            (odbc {:dsn "MyDsn" :make-pool? false})))))
 
 (deftest test-sqlite3
   (testing "sqlite3 - defaults"
     (is (= {:classname "org.sqlite.JDBC"
-            :subprotocol "sqlite"
-            :subname "sqlite.db"
+            :connection-uri "jdbc:sqlite:sqlite.db"
             :make-pool? true}
            (sqlite3 {}))))
   (testing "sqlite3 - options selected"
     (is (= {:classname "org.sqlite.JDBC"
-            :subprotocol "sqlite"
-            :subname "db"
+            :connection-uri "jdbc:sqlite:db"
             :make-pool? false}
            (sqlite3 {:db "db" :make-pool? false})))))
 
 (deftest test-h2
   (testing "h2 - defaults"
     (is (= {:classname "org.h2.Driver"
-            :subprotocol "h2"
-            :subname "h2.db"
+            :connection-uri "jdbc:h2:h2.db"
             :make-pool? true}
            (h2 {}))))
   (testing "h2 - options selected"
     (is (= {:classname "org.h2.Driver"
-            :subprotocol "h2"
-            :subname "db"
+            :connection-uri "jdbc:h2:db"
             :make-pool? false}
            (h2 {:db "db" :make-pool? false})))))
 


### PR DESCRIPTION
To be able to accept connection-uri from the user, we need to have the database specification function generate the connection-uri so that when they get one, they don't generate it and just pass it. This is the only way I found to implement accepting a connection-uri that doesn't require disassembling it to later on assembling it again.

Is this change acceptable? I'd like to settle this one before moving on.