### PR TITLE
Add function db-uri that takes any database connection-uri.

### DIFF
--- a/src/korma/db.clj
+++ b/src/korma/db.clj
@@ -251,6 +251,23 @@
           :make-pool? make-pool?}
          (dissoc opts :db)))
 
+(defn db-uri
+  "Create a database specification based on a URI. Opts should include a key for
+  :connection-uri and any other options you wish to pass as the database specification."
+  [{:keys [connection-uri] :as opts}]
+  (let [protocol (second (re-find #"jdbc:([^:]+):.*" connection-uri))]
+    (case protocol
+      "firebirdsql" (firebird opts)
+      "postgresql" (postgres opts)
+      "oracle" (oracle opts)
+      "mysql" (mysql opts)
+      "vertica" (vertica opts)
+      "sqlserver" (mssql opts)
+      "odbc" (odbc opts) ;; This will catch both odbc and msaccess. I'm not sure if there's any value in trying to match msaccess.
+      "sqlite" (sqlite3 opts)
+      "h2" (h2 opts)
+      (throw (Exception. (str "Unknown protocol \"" protocol "\" from URI \"" connection-uri "\" (with options: " opts ")"))))))
+
 (defmacro transaction
   "Execute all queries within the body in a single transaction.
   Optionally takes as a first argument a map to specify the :isolation and :read-only? properties of the transaction."

--- a/test/korma/test/db.clj
+++ b/test/korma/test/db.clj
@@ -3,7 +3,7 @@
         [korma.core :only [exec-raw]]
         [korma.db :only [connection-pool defdb get-connection h2 extract-options
                          msaccess mssql mysql odbc oracle postgres sqlite3 vertica
-                         firebird default-connection transaction]]))
+                         firebird db-uri default-connection transaction]]))
 
 (defdb mem-db (h2 {:db "mem:test"}))
 
@@ -105,6 +105,20 @@
                       :port "port"
                       :db "db"
                       :encoding "NONE"
+                      :make-pool? false}))))
+  (testing "firebirdsql - by connection uri"
+    (is (= {:classname "org.firebirdsql.jdbc.FBDriver"
+            :connection-uri "jdbc:firebirdsql:host/port:db"
+            :make-pool? true
+            :encoding "UTF8"}
+           (firebird {:connection-uri "jdbc:firebirdsql:host/port:db"}))))
+  (testing "firebirdsql - by connection uri with options"
+    (is (= {:classname "org.firebirdsql.jdbc.FBDriver"
+            :connection-uri "jdbc:firebirdsql:host/port:db"
+            :encoding "NONE"
+            :make-pool? false}
+           (firebird {:connection-uri "jdbc:firebirdsql:host/port:db"
+                      :encoding "NONE"
                       :make-pool? false})))))
 
 (deftest test-postgres
@@ -120,7 +134,18 @@
            (postgres {:host "host"
                       :port "port"
                       :db "db"
-                      :make-pool? false})))))
+                      :make-pool? false}))))
+  (testing "postgres by connection uri"
+    (is (= {:classname "org.postgresql.Driver"
+            :connection-uri "jdbc:postgresql://host:port/db"
+            :make-pool? true}
+           (db-uri {:connection-uri "jdbc:postgresql://host:port/db"}))))
+  (testing "postgres by connection uri with options"
+    (is (= {:classname "org.postgresql.Driver"
+            :connection-uri "jdbc:postgresql://host:port/db"
+            :make-pool? false}
+           (db-uri {:connection-uri "jdbc:postgresql://host:port/db"
+                    :make-pool? false})))))
 
 (deftest test-oracle
   (testing "oracle - defaults"
@@ -151,7 +176,20 @@
            (mysql {:host "host"
                    :port "port"
                    :db "db"
-                   :make-pool? false})))))
+                   :make-pool? false}))))
+  (testing "mysql - by connection uri"
+    (is (= {:classname "com.mysql.jdbc.Driver"
+            :connection-uri "jdbc:mysql://host:port/db"
+            :delimiters "`"
+            :make-pool? true}
+           (db-uri {:connection-uri "jdbc:mysql://host:port/db"}))))
+  (testing "mysql - by connection uri with options"
+    (is (= {:classname "com.mysql.jdbc.Driver"
+            :connection-uri "jdbc:mysql://host:port/db"
+            :delimiters "`"
+            :make-pool? false}
+           (db-uri {:connection-uri "jdbc:mysql://host:port/db"
+                    :make-pool? false})))))
 
 (deftest test-vertica
   (testing "vertica - defaults"
@@ -242,6 +280,11 @@
             :connection-uri "jdbc:h2:db"
             :make-pool? false}
            (h2 {:db "db" :make-pool? false})))))
+
+(deftest test-db-uri
+  (testing "exception on unrecognized protocol"
+    (is (thrown? Exception
+                 (db-uri {:connection-uri "jdbc:dbaseiii:db"})))))
 
 (deftest transaction-options
   (testing "if transaction macro respects isolation levels"


### PR DESCRIPTION
Based on the protocol specified in connection-uri, it’ll call the appropriate helper functions to add nice defaults, like the back tick for quoting in MySQL. It still accepts extra options, like :make-pool?. Tests included but not exhaustive.

I can write more tests if you feel it's needed. If you are happy with this change, I'll go and fix the documentation of db-uri and the other helper functions to account for connection-uri.