### PR TITLE
let query execute composable

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -106,8 +106,9 @@
 ;;*****************************************************
 
 (defn- make-query-then-exec [query-fn-var body & args]
-  `(let [query# (-> (~query-fn-var ~@args)
-                    ~@body)]
+  `(let [query# (binding [*exec-mode* :query]
+                  (-> (~query-fn-var ~@args)
+                      ~@body))]
      (exec query#)))
 
 (defmacro select

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -921,3 +921,17 @@
                              (with address-with-db
                                    (where {:status 1}))
                              (order :id)))))))
+
+
+;;*****************************************************
+;; Composable query execute
+;;****************************************************
+
+(deftest test-execute-query-comp
+  (letfn [(all-users []
+            (select users))]
+    (is (= "SELECT \"users\".* FROM \"users\""
+           (sql-only (all-users))))
+    (is (= "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"username\" = ?)"
+           (sql-only (select (all-users)
+                             (where {:username "chris"})))))))


### PR DESCRIPTION

Some times, we need make a query base an query.
We use `korma.core/select*`, but it is not convenient enough.
We can support nested query directly

```clojure
(defn list-featureA-users []
  (select users ...))

(defn list-featureA-and-featureB-users []
  (select (list-featureA-users) ...))
```
