### PR TITLE
Make order of values for insert queries not matter

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -298,7 +298,7 @@
 (def noop-query "DO 0")
 
 (defn sql-insert [query]
-  (let [ins-keys (sort (keys (first (:values query))))
+  (let [ins-keys (sort (distinct (mapcat keys (:values query))))
         keys-clause (utils/comma-separated (map field-identifier ins-keys))
         ins-values (insert-values-clause ins-keys (:values query))
         values-clause (utils/comma-separated ins-values)

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -154,6 +154,10 @@
         (insert users
                 (values [{:first "chris" :last "granger"}
                          {:last "jordan" :first "michael"}]))
+        "INSERT INTO \"users\" (\"first\", \"last\") VALUES (?, NULL), (?, ?)"
+        (insert users
+                (values [{:first "icarus"}
+                         {:first "chris" :last "granger"}]))
         "DO 0"
         (insert users (values {}))
         "DO 0"


### PR DESCRIPTION
So that the two following queries insert the same data:

```clj
(insert users
        (values [{:first "icarus"}
                 {:first "chris" :last "granger"}]))

(insert users
        (values [{:first "chris" :last "granger"}
                 {:first "icarus"}]))
```

Currently, the keys from the first map in `values` are used to determine the columns for an insert, which can lead to some values not being fully inserted.

I ran into this problem with a process that produced maps that may not include all the keys for a table. Finding out that the database was missing data was not fun.