### PR TITLE
Add ILIKE predicate

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -157,6 +157,7 @@
 ;;*****************************************************
 
 (def predicates {'like 'korma.sql.fns/pred-like
+                 'ilike 'korma.sql.fns/pred-ilike
                  'and 'korma.sql.fns/pred-and
                  'or 'korma.sql.fns/pred-or
                  'not 'korma.sql.fns/pred-not

--- a/src/korma/sql/fns.clj
+++ b/src/korma/sql/fns.clj
@@ -22,6 +22,7 @@
 (defn pred->= [k v]     (infix k ">=" v))
 (defn pred-<= [k v]     (infix k "<=" v))
 (defn pred-like [k v]   (infix k "LIKE" v))
+(defn pred-ilike [k v]  (infix k "ILIKE" v))
 
 (defn pred-exists [v]   (wrapper "EXISTS" v))
 

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -190,6 +190,9 @@
         "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"name\" LIKE ?)"
         (select users
                 (where {:name [like "chris"]}))
+        "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"name\" ILIKE ?)"
+        (select users
+                (where {:name [ilike "chris"]}))
         "SELECT \"users\".* FROM \"users\" WHERE ((\"users\".\"name\" LIKE ?) OR \"users\".\"name\" LIKE ?)"
         (select users
                 (where (or {:name [like "chris"]}


### PR DESCRIPTION
Only PostgreSQL supports ILIKE for case-insensitive string comparison, but it would be nice to have it in Korma nevertheless.