### PR TITLE
Update entity-fields documentation

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -669,7 +669,7 @@
    `(many-to-many-fn ~ent (var ~sub-ent) ~join-table ~opts)))
 
 (defn entity-fields
-  "Set the fields to be retrieved by default in select queries for the
+  "Set the fields to be retrieved in all select queries for the
   entity."
   [ent & fields]
   (update-in ent [:fields] utils/vconcat fields))


### PR DESCRIPTION
I wanted to make it clearer that entity-fields are _always_ included in select results, since I was surprised by that the first time I used this library (and others have as well - see #251, #340). Would this help? 