### PR TITLE
supprot predicate keyword

### DIFF
--- a/src/korma/sql/engine.clj
+++ b/src/korma/sql/engine.clj
@@ -156,22 +156,24 @@
 ;; Predicates
 ;;*****************************************************
 
-(def predicates {'like 'korma.sql.fns/pred-like
-                 'ilike 'korma.sql.fns/pred-ilike
-                 'and 'korma.sql.fns/pred-and
-                 'or 'korma.sql.fns/pred-or
-                 'not 'korma.sql.fns/pred-not
-                 'in 'korma.sql.fns/pred-in
-                 'exists 'korma.sql.fns/pred-exists
-                 'not-in 'korma.sql.fns/pred-not-in
-                 'between 'korma.sql.fns/pred-between
-                 '> 'korma.sql.fns/pred->
-                 '< 'korma.sql.fns/pred-<
-                 '>= 'korma.sql.fns/pred->=
-                 '<= 'korma.sql.fns/pred-<=
-                 'not= 'korma.sql.fns/pred-not=
-                 '= 'korma.sql.fns/pred-=})
-
+(def predicates
+  (let [predicates-s {'like    'korma.sql.fns/pred-like
+                      'ilike   'korma.sql.fns/pred-ilike
+                      'and     'korma.sql.fns/pred-and
+                      'or      'korma.sql.fns/pred-or
+                      'not     'korma.sql.fns/pred-not
+                      'in      'korma.sql.fns/pred-in
+                      'exists  'korma.sql.fns/pred-exists
+                      'not-in  'korma.sql.fns/pred-not-in
+                      'between 'korma.sql.fns/pred-between
+                      '>       'korma.sql.fns/pred->
+                      '<       'korma.sql.fns/pred-<
+                      '>=      'korma.sql.fns/pred->=
+                      '<=      'korma.sql.fns/pred-<=
+                      'not=    'korma.sql.fns/pred-not=
+                      '=       'korma.sql.fns/pred-=}
+        predicates-k (into {} (map (fn [[k v]] {(keyword k) v}) predicates-s))]
+    (merge predicates-s predicates-k)))
 
 (defn do-infix [k op v]
   (string/join " " [(str-value k) op (str-value v)]))

--- a/test/korma/test/core.clj
+++ b/test/korma/test/core.clj
@@ -624,24 +624,31 @@
 
 (deftest predicates-used-with-brackets
   (sql-only
-   (are [result query] (= result query)
+   (are [result query queryk] (= result query queryk)
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" = ?)"
         (select :test (where {:id [= 1]}))
+        (select :test (where {:id [:= 1]}))
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" < ?)"
         (select :test (where {:id [< 10]}))
+        (select :test (where {:id [:< 10]}))
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" <= ?)"
         (select :test (where {:id [<= 10]}))
+        (select :test (where {:id [:<= 10]}))
         "SELECT \"test\".* FROM \"test\" WHERE ((\"test\".\"id\" BETWEEN ? AND ?))"
         (select :test (where {:id [between [1 10]]}))
+        (select :test (where {:id [:between [1 10]]}))
 
         ;; clearly this is not an intended use of 'or'!
         "SELECT \"test\".* FROM \"test\" WHERE ((\"test\".\"id\" OR (?, ?, ?)))"
         (select :test (where {:id [or [1 2 3]]}))
+        (select :test (where {:id [:or [1 2 3]]}))
 
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" NOT IN (?, ?, ?))"
         (select :test (where {:id [not-in [1 2 3]]}))
+        (select :test (where {:id [:not-in [1 2 3]]}))
         "SELECT \"test\".* FROM \"test\" WHERE (\"test\".\"id\" <> ?)"
-        (select :test (where {:id [not= 1]})))))
+        (select :test (where {:id [not= 1]}))
+        (select :test (where {:id [:not= 1]})))))
 
 
 ;;*****************************************************


### PR DESCRIPTION
i wonder if we can use both keyword and symbol to present predicates, this is really useful when we construct queries with predicate in a macro, make the code more readable.