### PR TITLE
Field macro is not showing only the desired fields

### DIFF
--- a/src/korma/sql/utils.clj
+++ b/src/korma/sql/utils.clj
@@ -58,4 +58,5 @@
 ;;*****************************************************
 
 (defn vconcat [v1 v2]
-  (vec (concat v1 v2)))
+  (let [diff (clojure.set/intersection (set v1) (set v2))]
+    (vec (if (empty? diff) (concat (or v1 []) v2) diff))))


### PR DESCRIPTION
Ref: https://github.com/korma/Korma/issues/340
    
I still had the problem listed on the issue, even using fields or
    entity-fields on defentity definition.

    You can reproduce the issue with this:
     user> (defentity sample1
             (fields :id :name :birthday :gender))

     user> (sql-only (select sample1
                        (fields :id)))
     => "SELECT \"sample1\".\"id\", \"sample1\".\"name\",
\"sample1\".\"birthday\", \"sample1\".\"gender\", \"sample1\".\"id\"
FROM \"sample1\""

      user> (defentity sample2
              (entity-fields :id :name :bithday :gender))

      user> (sql-only (select sample2
                        (fields :id)))
      => "SELECT \"sample2\".\"id\", \"sample2\".\"name\",
\"sample2\".\"birthday\", \"sample2\".\"gender\", \"sample2\".\"id\"
FROM \"sample2\""

    As we can see in both generated queries, instead filtering the
desired
    field, the field was added to the field list...

    So, I made a change on the db/utils vconcat function to validate it
and
    the result is this:

     user> (defentity sample1
             (fields :id :name :birthday :gender))
     => "SELECT \"sample1\".\"id\" FROM \"sample1\""

    Or even

     user> (defentity user
             (fields :id :name :birthday :gender)
             (has-many address))

     user> (defentity address
             (belongs-to user)
             (entity-fields :id :address :number :user_id))

     user> (dry-run (select user
                      (fields :id :name)
                      (with address
                         (fields :address :number))))
     => dry run :: SELECT "user"."name", "user"."id" FROM "user" :: []
        dry run :: SELECT "address"."address", "address"."number" FROM
"address" WHERE ("address"."user_id" = ?) :: [1]
        ({:id 1, :address [{:id 1, :user_id 1}]})

        {:id 1 :name "Freddy" :address {[:address "Elm Street" :number
"1428"]}}