### PR TITLE
Upgrade clojure.java.jdbc to 0.6.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.mchange/c3p0 "0.9.5.2"]
-                 [org.clojure/java.jdbc "0.3.7"]]
+                 [org.clojure/java.jdbc "0.6.1"]]
 
   :min-lein-version "2.0.0"
 

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,6 @@
              :test {:dependencies [[mysql/mysql-connector-java "5.1.35"]
                                    [com.h2database/h2 "1.4.187"]
                                    [criterium "0.4.3"]]}
-             :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/test/korma/test/integration/mysql.clj
+++ b/test/korma/test/integration/mysql.clj
@@ -12,9 +12,10 @@
   {:connection-uri "jdbc:mysql://localhost/?user=root"})
 
 (defn- setup-korma-db []
-  (jdbc/db-do-commands mysql-uri "CREATE DATABASE IF NOT EXISTS korma;"
-                       "USE korma;"
-                       "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200));"))
+  (jdbc/db-do-commands mysql-uri
+                       ["CREATE DATABASE IF NOT EXISTS korma;"
+                        "USE korma;"
+                        "CREATE TABLE IF NOT EXISTS `users-live-mysql` (name varchar(200));"]))
 
 (defn- clean-korma-db []
   (jdbc/db-do-commands mysql-uri "DROP DATABASE korma;"))


### PR DESCRIPTION
This commit updates clojure.java.jdbc to 0.6.1. This update is important
in that it also addresses a number of cases in which features have not
only been deprecated but officially dropped in the 0.6.x branch.

It also drops support for Clojure 1.3.0, since clojure.java.jdbc now includes a call to `reduce-kv`, which was only introduced in Clojure 1.4.0.

Relates to #357 