### PR TITLE
[fix] Fix argslist metadata for join

### DIFF
--- a/src/korma/core.clj
+++ b/src/korma/core.clj
@@ -326,7 +326,7 @@
   (join query :right addresses)
   (join query addresses (= :addres.users_id :users.id))
   (join query :right addresses (= :address.users_id :users.id))"
-  {:arglists '([query ent] [query type ent] [query table clause] [query type table clause])}
+  {:arglists '([query ent] [query type-or-table ent-or-clause] [query type table clause])}
   ([query ent]
    `(join ~query :left ~ent))
   ([query type-or-table ent-or-clause]


### PR DESCRIPTION
Although the current arglists metadata for korma.core/join is helpful to a human
user, it's technically invalid for machines. Any compiler obeying the Clojure
spec that attempts to parse the `join` macro will announce that a function
cannot have two overloads with the same arity. We might benefit from expanding
the documentation in this case to make up for the change.